### PR TITLE
ReglasNegocio, Clases de Causa, Logica para el estado de los informes…

### DIFF
--- a/Backend/ICE.Capa_Datos/Acciones/GestionarCausaDA.cs
+++ b/Backend/ICE.Capa_Datos/Acciones/GestionarCausaDA.cs
@@ -1,0 +1,84 @@
+using ICE.Capa_Datos.Contexto;
+using ICE.Capa_Datos.Entidades;
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ICE.Capa_Datos.Acciones
+{
+    public class GestionarCausaDA : IGestionarCausaDA
+    {
+        private readonly ICE_Context _context;
+
+        public GestionarCausaDA(ICE_Context context)
+        {
+            _context = context;
+        }
+
+        public async Task<bool> RegistrarCausa(Causa causa)
+        {
+            var causaDA = new CausaDA
+            {
+                Descripcion = causa.Descripcion
+            };
+
+            _context.Causas.Add(causaDA);
+            var resultado = await _context.SaveChangesAsync();
+            return resultado > 0;
+        }
+
+        public async Task<bool> ActualizarCausa(int id, Causa causa)
+        {
+            var causaBD = await _context.Causas.FirstOrDefaultAsync(c => c.Id == id);
+            if (causaBD != null)
+            {
+                causaBD.Descripcion = causa.Descripcion;
+
+                var resultado = await _context.SaveChangesAsync();
+                return resultado > 0;
+            }
+            return false;
+        }
+
+        public async Task<bool> EliminarCausa(int id)
+        {
+            var causaBD = await _context.Causas.FirstOrDefaultAsync(c => c.Id == id);
+            if (causaBD != null)
+            {
+                _context.Causas.Remove(causaBD);
+                var resultado = await _context.SaveChangesAsync();
+                return resultado > 0;
+            }
+            return false;
+        }
+
+        public async Task<Causa> ObtenerCausaPorId(int id)
+        {
+            var causaBD = await _context.Causas.FirstOrDefaultAsync(c => c.Id == id);
+            if (causaBD == null)
+            {
+                return null;
+            }
+
+            return new Causa
+            {
+                Id = causaBD.Id,
+                Descripcion = causaBD.Descripcion
+            };
+        }
+        
+        public async Task<IEnumerable<Causa>> ObtenerTodasLasCausas()
+        {
+            var causasBD = await _context.Causas.ToListAsync();
+
+            return causasBD.Select(causaBD => new Causa
+            {
+                Id = causaBD.Id,
+                Descripcion = causaBD.Descripcion
+            }).ToList();
+        }
+    }
+}

--- a/Backend/ICE.Capa_Datos/Acciones/GestionarInformeDA.cs
+++ b/Backend/ICE.Capa_Datos/Acciones/GestionarInformeDA.cs
@@ -56,36 +56,7 @@ namespace ICE.Capa_Datos.Acciones
             await _context.SaveChangesAsync();
             return informeDA.Id;
 
-            //var resultado = await _context.SaveChangesAsync();
-            //return resultado > 0;
         }
-
-
-
-        /*
-        public async Task<bool> ActualizarInforme(int id, Informe informe)
-        {
-            var informeBD = await _context.Informes.FirstOrDefaultAsync(i => i.Id == id);
-            if (informeBD != null)
-            {
-                informeBD.Tipo = informe.Tipo;
-                informeBD.SubestacionId = informe.SubestacionId;
-                informeBD.LineaTransmisionId = informe.LineaTransmisionId;
-                informeBD.DatosDeLineaId = informe.DatosDeLineaId;
-                informeBD.DatosGeneralesId = informe.DatosGeneralesId;
-                informeBD.TeleproteccionId = informe.TeleproteccionId;
-                informeBD.DistanciaDeFallaId = informe.DistanciaDeFallaId;
-                informeBD.TiemposDeDisparoId = informe.TiemposDeDisparoId;
-                informeBD.CorrientesDeFallaId = informe.CorrientesDeFallaId;
-                informeBD.Estado = informe.Estado;
-
-                var resultado = await _context.SaveChangesAsync();
-                return resultado > 0;
-            }
-            return false;
-        }
-        */
-
 
         public async Task<bool> ActualizarInforme(int id, Informe informe)
         {
@@ -102,7 +73,6 @@ namespace ICE.Capa_Datos.Acciones
                         .Include(i => i.TiemposDeDisparo)
                         .Include(i => i.CorrientesDeFalla)
                         .FirstOrDefaultAsync(i => i.Id == id);
-
 
                     //se actualizan los campos simples del informe
                     informeBD.Tipo = informe.Tipo;

--- a/Backend/ICE.Capa_Datos/Acciones/GestionarReporteDA.cs
+++ b/Backend/ICE.Capa_Datos/Acciones/GestionarReporteDA.cs
@@ -1,0 +1,129 @@
+﻿using ICE.Capa_Datos.Contexto;
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Datos.Entidades;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ICE.Capa_Datos.Acciones
+{
+    public class GestionarReporteDA : IGestionarReporteDA
+    {
+        private readonly ICE_Context _context;
+
+        public GestionarReporteDA(ICE_Context context)
+        {
+            _context = context;
+        }
+
+        public async Task<bool> RegistrarReporte(Reporte reporte)
+        {
+            var reporteDA = new ReporteDA
+            {
+                MapaDeDescargas = reporte.MapaDeDescargas,
+                Observaciones = reporte.Observaciones,
+                InformeV1Id = reporte.InformeV1Id,
+                InformeV2Id = reporte.InformeV2Id,
+                InformeV3Id = reporte.InformeV3Id,
+                InformeV4Id = reporte.InformeV4Id,
+                Estado = reporte.Estado,
+                UsuarioSupervisorId = reporte.UsuarioSupervisorId,
+                TecnicoLineaId = reporte.TecnicoLineaId
+            };
+
+            _context.Reportes.Add(reporteDA);
+            var resultado = await _context.SaveChangesAsync();
+            return resultado > 0;
+        }
+
+        public async Task<bool> ActualizarReporte(int id, Reporte reporte)
+        {
+            var reporteBD = await _context.Reportes.FirstOrDefaultAsync(r => r.Id == id);
+            if (reporteBD != null)
+            {
+                reporteBD.MapaDeDescargas = reporte.MapaDeDescargas;
+                reporteBD.Observaciones = reporte.Observaciones;
+                reporteBD.InformeV1Id = reporte.InformeV1Id;
+                reporteBD.InformeV2Id = reporte.InformeV2Id;
+                reporteBD.InformeV3Id = reporte.InformeV3Id;
+                reporteBD.InformeV4Id = reporte.InformeV4Id;
+                reporteBD.Estado = reporte.Estado;
+                reporteBD.UsuarioSupervisorId = reporte.UsuarioSupervisorId;
+                reporteBD.TecnicoLineaId = reporte.TecnicoLineaId;
+
+                var resultado = await _context.SaveChangesAsync();
+                return resultado > 0;
+            }
+            return false;
+        }
+
+        public async Task<bool> EliminarReporte(int id)
+        {
+            var reporteBD = await _context.Reportes.FirstOrDefaultAsync(r => r.Id == id);
+            if (reporteBD != null)
+            {
+                _context.Reportes.Remove(reporteBD);
+                var resultado = await _context.SaveChangesAsync();
+                return resultado > 0;
+            }
+            return false;
+        }
+
+        public async Task<Reporte> ObtenerReportePorId(int id)
+        {
+            var reporteBD = await _context.Reportes.FirstOrDefaultAsync(r => r.Id == id);
+            if (reporteBD == null)
+            {
+                return null;
+            }
+
+            return new Reporte
+            {
+                Id = reporteBD.Id,
+                MapaDeDescargas = reporteBD.MapaDeDescargas,
+                Observaciones = reporteBD.Observaciones,
+                InformeV1Id = reporteBD.InformeV1Id,
+                InformeV2Id = reporteBD.InformeV2Id,
+                InformeV3Id = reporteBD.InformeV3Id,
+                InformeV4Id = reporteBD.InformeV4Id,
+                Estado = reporteBD.Estado,
+                UsuarioSupervisorId = reporteBD.UsuarioSupervisorId,
+                TecnicoLineaId = reporteBD.TecnicoLineaId
+            };
+        }
+
+        public async Task<IEnumerable<Reporte>> ObtenerTodosLosReportes()
+        {
+            var reportesBD = await _context.Reportes.ToListAsync();
+
+            return reportesBD.Select(reporteBD => new Reporte
+            {
+                Id = reporteBD.Id,
+                MapaDeDescargas = reporteBD.MapaDeDescargas,
+                Observaciones = reporteBD.Observaciones,
+                InformeV1Id = reporteBD.InformeV1Id,
+                InformeV2Id = reporteBD.InformeV2Id,
+                InformeV3Id = reporteBD.InformeV3Id,
+                InformeV4Id = reporteBD.InformeV4Id,
+                Estado = reporteBD.Estado,
+                UsuarioSupervisorId = reporteBD.UsuarioSupervisorId,
+                TecnicoLineaId = reporteBD.TecnicoLineaId
+            }).ToList();
+        }
+
+
+        public async Task<IEnumerable<int>> ObtenerIdsInformesDeReporte(int informeId)
+        {
+            //Se busca el reporte con el id asociado
+            var reporte = await _context.Reportes
+                .Where(r => r.InformeV1Id == informeId || r.InformeV2Id == informeId || r.InformeV3Id == informeId || r.InformeV4Id == informeId)
+                .Select(r => new List<int> { r.InformeV1Id, r.InformeV2Id, r.InformeV3Id, r.InformeV4Id })
+                .FirstOrDefaultAsync();
+
+            //Si no se ecuentra el reporte, se obtiene una lista vacia
+            return reporte ?? new List<int>();
+        }
+    }
+}

--- a/Backend/ICE.Capa_Logica/CU/GestionarCausaCN.cs
+++ b/Backend/ICE.Capa_Logica/CU/GestionarCausaCN.cs
@@ -1,0 +1,65 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using ICE.Capa_Dominio.ReglasDeNegocio;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+
+namespace ICE.Capa_Negocios.CU
+{
+    public class GestionarCausaCN : IGestionarCausaCN
+    {
+        private readonly IGestionarCausaDA _gestionarCausaDA;
+
+        public GestionarCausaCN(IGestionarCausaDA gestionarCausaDA)
+        {
+            _gestionarCausaDA = gestionarCausaDA;
+        }
+
+        public async Task<bool> ActualizarCausa(int id, Causa causa)
+        {
+            var validacion = ReglasCausa.EsCausaValida(causa);
+            var validacionID = ReglasCausa.EsIdValido(id);
+
+            if (!validacion.esValido || !validacionID.esValido)
+                return false;
+
+            return await _gestionarCausaDA.ActualizarCausa(id, causa);
+        }
+
+        public async Task<bool> EliminarCausa(int id)
+        {
+            var validacionID = ReglasCausa.EsIdValido(id);
+
+            if (!validacionID.esValido)
+                return false;
+
+            return await _gestionarCausaDA.EliminarCausa(id);
+        }
+
+        public async Task<Causa> ObtenerCausaPorId(int id)
+        {
+            var validacionID = ReglasCausa.EsIdValido(id);
+
+            if (!validacionID.esValido)
+                return null;
+
+            return await _gestionarCausaDA.ObtenerCausaPorId(id);
+        }
+
+        public async Task<IEnumerable<Causa>> ObtenerTodasLasCausas()
+        {
+            return await _gestionarCausaDA.ObtenerTodasLasCausas();
+        }
+
+        public async Task<bool> RegistrarCausa(Causa causa)
+        {
+            var validacion = ReglasCausa.EsCausaValida(causa);
+
+            if (!validacion.esValido)
+                return false;
+
+            return await _gestionarCausaDA.RegistrarCausa(causa);
+        }
+    }
+}

--- a/Backend/ICE.Capa_Logica/CU/GestionarReporteCN.cs
+++ b/Backend/ICE.Capa_Logica/CU/GestionarReporteCN.cs
@@ -1,0 +1,49 @@
+﻿using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE.Capa_Negocios.CU
+{
+    public class GestionarReporteCN : IGestionarReporteCN
+    {
+        private readonly IGestionarReporteDA _gestionarReporteDA;
+
+        public GestionarReporteCN(IGestionarReporteDA gestionarReporteDA)
+        {
+            _gestionarReporteDA = gestionarReporteDA;
+        }
+
+        public async Task<bool> RegistrarReporte(Reporte reporte)
+        {
+            return await _gestionarReporteDA.RegistrarReporte(reporte);
+        }
+
+        public async Task<bool> ActualizarReporte(int id, Reporte reporte)
+        {
+            return await _gestionarReporteDA.ActualizarReporte(id, reporte);
+        }
+
+        public async Task<bool> EliminarReporte(int id)
+        {
+            return await _gestionarReporteDA.EliminarReporte(id);
+        }
+
+        public async Task<Reporte> ObtenerReportePorId(int id)
+        {
+            return await _gestionarReporteDA.ObtenerReportePorId(id);
+        }
+
+        public async Task<IEnumerable<Reporte>> ObtenerTodosLosReportes()
+        {
+            return await _gestionarReporteDA.ObtenerTodosLosReportes();
+        }
+
+        public async Task<IEnumerable<int>> ObtenerIdsInformesDeReporte(int informeId)
+        {
+            // Llamada al método de la capa de datos para obtener los IDs de los informes asociados al reporte
+            return await _gestionarReporteDA.ObtenerIdsInformesDeReporte(informeId);
+        }        
+    }
+}

--- a/Backend/ICE.Capa_Logica/Interfaces/Capa_Datos/IGestionarCausaDA.cs
+++ b/Backend/ICE.Capa_Logica/Interfaces/Capa_Datos/IGestionarCausaDA.cs
@@ -1,0 +1,15 @@
+using ICE.Capa_Dominio.Modelos;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE.Capa_Negocios.Interfaces.Capa_Datos
+{
+    public interface IGestionarCausaDA
+    {     
+        Task<bool> RegistrarCausa(Causa causa);     
+        Task<bool> ActualizarCausa(int id, Causa causa);        
+        Task<bool> EliminarCausa(int id);        
+        Task<Causa> ObtenerCausaPorId(int id);        
+        Task<IEnumerable<Causa>> ObtenerTodasLasCausas();
+    }
+}

--- a/Backend/ICE.Capa_Logica/Interfaces/Capa_Datos/IGestionarReporteCausaDA.cs
+++ b/Backend/ICE.Capa_Logica/Interfaces/Capa_Datos/IGestionarReporteCausaDA.cs
@@ -1,0 +1,18 @@
+using ICE.Capa_Dominio.Modelos;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ICE.Capa_Negocios.Interfaces.Capa_Datos
+{
+    public interface IGestionarReporteCausaDA
+    {        
+        Task<bool> RegistrarReporteCausa(int reporteId, int causaId);     
+        Task<IEnumerable<Causa>> ObtenerCausasPorReporteId(int reporteId);        
+        Task<IEnumerable<Reporte>> ObtenerReportesPorCausaId(int causaId);        
+        Task<bool> ActualizarReporteCausa(int id, int nuevoReporteId, int nuevaCausaId);
+        Task<bool> EliminarReporteCausa(int id);
+    }
+}

--- a/Backend/ICE.Capa_Logica/Interfaces/Capa_Datos/IGestionarReporteDA.cs
+++ b/Backend/ICE.Capa_Logica/Interfaces/Capa_Datos/IGestionarReporteDA.cs
@@ -11,5 +11,6 @@ namespace ICE.Capa_Negocios.Interfaces.Capa_Datos
         Task<bool> EliminarReporte(int id);
         Task<Reporte> ObtenerReportePorId(int id);
         Task<IEnumerable<Reporte>> ObtenerTodosLosReportes();
+        Task<IEnumerable<int>> ObtenerIdsInformesDeReporte(int informeId);        
     }
 }

--- a/Backend/ICE.Capa_Logica/Interfaces/Capa_Negocios/IGestionarCausaCN.cs
+++ b/Backend/ICE.Capa_Logica/Interfaces/Capa_Negocios/IGestionarCausaCN.cs
@@ -1,0 +1,15 @@
+using ICE.Capa_Dominio.Modelos;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE.Capa_Negocios.Interfaces.Capa_Negocios
+{
+    public interface IGestionarCausaCN
+    {
+        Task<bool> ActualizarCausa(int id, Causa causa);
+        Task<bool> EliminarCausa(int id);        
+        Task<Causa> ObtenerCausaPorId(int id);
+        Task<IEnumerable<Causa>> ObtenerTodasLasCausas();
+        Task<bool> RegistrarCausa(Causa causa);
+    }
+}

--- a/Backend/ICE.Capa_Logica/Interfaces/Capa_Negocios/IGestionarReporteCN.cs
+++ b/Backend/ICE.Capa_Logica/Interfaces/Capa_Negocios/IGestionarReporteCN.cs
@@ -11,5 +11,6 @@ namespace ICE.Capa_Negocios.Interfaces.Capa_Negocios
         Task<bool> EliminarReporte(int id);
         Task<Reporte> ObtenerReportePorId(int id);
         Task<IEnumerable<Reporte>> ObtenerTodosLosReportes();
+        Task<IEnumerable<int>> ObtenerIdsInformesDeReporte(int informeId);
     }
 }

--- a/Backend/ICE.Capa_Logica/Interfaces/Capa_Negocios/IGestionarReporteConInformesService.cs
+++ b/Backend/ICE.Capa_Logica/Interfaces/Capa_Negocios/IGestionarReporteConInformesService.cs
@@ -6,5 +6,16 @@ namespace ICE.Capa_Negocios.Interfaces.Capa_Negocios
     public interface IGestionarReporteConInformesService
     {
         Task<bool> RegistrarReporteConInformes(Reporte reporte, List<int> subestacionIds, int lineaTransmisionId);
+        Task VerificarEstadoInformesAsociados(int informeId);
+
+        /// <summary>
+        /// Verifica si al menos uno de los informes asociados a un reporte está completo.
+        /// </summary>
+        Task<bool> VerificarInformesCompletosAsociados(int informeId);
+
+        /// <summary>
+        /// Cambia el estado de todos los informes asociados a "pendiente" si no hay informes completos.
+        /// </summary>
+        Task<bool> ActualizarEstadosDeInformesAPendiente(int informeId);        
     }
 }

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasCausa.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasCausa.cs
@@ -1,0 +1,42 @@
+using ICE.Capa_Dominio.Modelos;
+
+namespace ICE.Capa_Dominio.ReglasDeNegocio
+{
+    public static class ReglasCausa
+    {
+        // Método para validar que la instancia de Causa es válida
+        public static (bool esValido, string mensaje) EsCausaValida(Causa causa)
+        {
+            if (causa == null)
+            {
+                return (false, "La causa no debe ser nula.");
+            }
+
+            // Validación del Id
+            if (causa.Id <= 0)
+            {
+                return (false, "El ID de la causa debe ser mayor que cero.");
+            }
+
+            // Validación de la Descripción
+            if (string.IsNullOrWhiteSpace(causa.Descripcion))
+            {
+                return (false, "La descripción de la causa no debe estar vacía.");
+            }
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+        }
+
+        // Método adicional para verificar que el ID es válido (por separado)
+        public static (bool esValido, string mensaje) EsIdValido(int id)
+        {
+            if (id <= 0)
+            {
+                return (false, "El ID debe ser mayor que cero.");
+            }
+
+            return (true, string.Empty);
+        }
+    }
+}

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasCorrientesDeFalla.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasCorrientesDeFalla.cs
@@ -1,0 +1,62 @@
+using ICE.Capa_Dominio.Modelos;
+
+namespace ICE.Capa_Dominio.ReglasDeNegocio
+{
+    public static class ReglasCorrientesDeFalla
+    {
+        public static (bool esValido, string mensaje) EsCorrientesDeFallaValido(CorrientesDeFalla corrientesDeFalla)
+        {
+            if (corrientesDeFalla == null)
+            {
+                return (false, "Las corrientes de falla no deben ser nulas.");
+            }
+
+            // Validación del Id
+            if (corrientesDeFalla.Id <= 0)
+            {
+                return (false, "El ID de corrientes de falla debe ser mayor que cero.");
+            }
+            
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+        }
+        public static (bool esValido, string mensaje) EsCorrientesDeFallaCompleto(CorrientesDeFalla corrientesDeFalla)
+        {
+            // Validación de los campos RealIR, RealIS, RealIT
+            if (string.IsNullOrWhiteSpace(corrientesDeFalla.RealIR))
+            {
+                return (false, "El valor de RealIR no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(corrientesDeFalla.RealIS))
+            {
+                return (false, "El valor de RealIS no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(corrientesDeFalla.RealIT))
+            {
+                return (false, "El valor de RealIT no debe estar vacío.");
+            }
+
+            // Validación de los campos AcumuladaR, AcumuladaS, AcumuladaT
+            if (string.IsNullOrWhiteSpace(corrientesDeFalla.AcumuladaR))
+            {
+                return (false, "El valor de AcumuladaR no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(corrientesDeFalla.AcumuladaS))
+            {
+                return (false, "El valor de AcumuladaS no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(corrientesDeFalla.AcumuladaT))
+            {
+                return (false, "El valor de AcumuladaT no debe estar vacío.");
+            }
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+        }
+    }
+}

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasDatosDeLinea.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasDatosDeLinea.cs
@@ -1,0 +1,62 @@
+using ICE.Capa_Dominio.Modelos;
+
+namespace ICE.Capa_Dominio.ReglasDeNegocio
+{
+    public static class ReglasDatosDeLinea
+    {
+        public static (bool esValido, string mensaje) EsDatosDeLineaValido(DatosDeLinea datosDeLinea)
+        {
+            if (datosDeLinea == null)
+            {
+                return (false, "Los datos de línea no deben ser nulos.");
+            }
+
+            // Validación del Id
+            if (datosDeLinea.Id <= 0)
+            {
+                return (false, "El ID de datos de línea debe ser mayor que cero.");
+            }
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+        }
+
+        public static (bool esValido, string mensaje) EsDatosDeLineaCompleto(DatosDeLinea datosDeLinea)
+        {
+            // Validación de los campos OT, Aviso, SAP, Distancia, Funcion y Zona
+            if (string.IsNullOrWhiteSpace(datosDeLinea.OT))
+            {
+                return (false, "El campo OT no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(datosDeLinea.Aviso))
+            {
+                return (false, "El campo Aviso no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(datosDeLinea.SAP))
+            {
+                return (false, "El campo SAP no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(datosDeLinea.Distancia))
+            {
+                return (false, "El campo Distancia no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(datosDeLinea.Funcion))
+            {
+                return (false, "El campo Funcion no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(datosDeLinea.Zona))
+            {
+                return (false, "El campo Zona no debe estar vacío.");
+            }
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+
+        }
+    }
+}

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasDatosGenerales.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasDatosGenerales.cs
@@ -1,0 +1,65 @@
+using ICE.Capa_Dominio.Modelos;
+using System;
+
+namespace ICE.Capa_Dominio.ReglasDeNegocio
+{
+    public static class ReglasDatosGenerales
+    {
+        public static (bool esValido, string mensaje) EsDatosGeneralesValido(DatosGenerales datosGenerales)
+        {
+            if (datosGenerales == null)
+            {
+                return (false, "Los datos generales no deben ser nulos.");
+            }
+
+            // Validación del Id
+            if (datosGenerales.Id <= 0)
+            {
+                return (false, "El ID de datos generales debe ser mayor que cero.");
+            }
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);                        
+        }
+                
+        public static (bool esValido, string mensaje) EsDatosGeneralesCompleto(DatosGenerales datosGenerales) 
+        {
+
+            // Validación de campos de texto (Evento, Subestacion, LT y Equipo)
+            if (string.IsNullOrWhiteSpace(datosGenerales.Evento))
+            {
+                return (false, "El campo Evento no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(datosGenerales.Subestacion))
+            {
+                return (false, "El campo Subestacion no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(datosGenerales.LT))
+            {
+                return (false, "El campo LT no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(datosGenerales.Equipo))
+            {
+                return (false, "El campo Equipo no debe estar vacío.");
+            }
+
+            // Validación de Fecha y Hora
+            if (!datosGenerales.Fecha.HasValue)
+            {
+                return (false, "La Fecha no debe ser nula.");
+            }
+
+            if (!datosGenerales.Hora.HasValue)
+            {
+                return (false, "La Hora no debe ser nula.");
+            }
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+
+        }
+    }
+}

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasDistanciaDeFalla.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasDistanciaDeFalla.cs
@@ -1,0 +1,63 @@
+using ICE.Capa_Dominio.Modelos;
+
+namespace ICE.Capa_Dominio.ReglasDeNegocio
+{
+    public static class ReglasDistanciaDeFalla
+    {
+        public static (bool esValido, string mensaje) EsDistanciaDeFallaValido(DistanciaDeFalla distanciaDeFalla)
+        {
+            if (distanciaDeFalla == null)
+            {
+                return (false, "La distancia de falla no debe ser nula.");
+            }
+
+            // Validación del Id
+            if (distanciaDeFalla.Id <= 0)
+            {
+                return (false, "El ID de distancia de falla debe ser mayor que cero.");
+            }
+            
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+        }
+
+        public static (bool esValido, string mensaje) EsDistanciaDeFallaCompleto(DistanciaDeFalla distanciaDeFalla)
+        {
+
+            // Validación de los campos DistanciaKM, DistanciaPorcentaje, DistanciaReportada, DistanciaDobleTemporal, Error, y Error_Doble
+            if (string.IsNullOrWhiteSpace(distanciaDeFalla.DistanciaKM))
+            {
+                return (false, "El campo DistanciaKM no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(distanciaDeFalla.DistanciaPorcentaje))
+            {
+                return (false, "El campo DistanciaPorcentaje no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(distanciaDeFalla.DistanciaReportada))
+            {
+                return (false, "El campo DistanciaReportada no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(distanciaDeFalla.DistanciaDobleTemporal))
+            {
+                return (false, "El campo DistanciaDobleTemporal no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(distanciaDeFalla.Error))
+            {
+                return (false, "El campo Error no debe estar vacío.");
+            }
+
+            if (string.IsNullOrWhiteSpace(distanciaDeFalla.Error_Doble))
+            {
+                return (false, "El campo Error_Doble no debe estar vacío.");
+            }
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+        }
+    }
+}

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasInforme.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasInforme.cs
@@ -1,0 +1,102 @@
+using ICE.Capa_Dominio.Modelos;
+using System.Threading.Tasks;
+
+namespace ICE.Capa_Dominio.ReglasDeNegocio
+{
+    public static class ReglasInforme
+    {
+        // Validar los datos del Informe
+        public static (bool esValido, string mensaje) EsInformeValido(Informe informe)
+        {
+            if (informe == null)
+                throw new ArgumentNullException(nameof(informe), "El informe no puede ser nulo.");
+
+            // Validación del Estado
+            if (informe.Estado < 0 || informe.Estado > 1)
+                return (false, "El estado del informe debe ser 0 o 1.");
+
+            // Validación del Tipo
+            if (informe.Tipo != 1 && informe.Tipo != 2)
+                return (false, "El tipo de informe debe ser 1 o 2.");
+
+            // Validación de las instancias de Informe utilizando las reglas específicas de cada instancia
+
+            var validacionDatosDeLinea = ReglasDatosDeLinea.EsDatosDeLineaValido(informe.DatosDeLinea);
+            if (!validacionDatosDeLinea.esValido)
+                return validacionDatosDeLinea;
+
+            var validacionDatosGenerales = ReglasDatosGenerales.EsDatosGeneralesValido(informe.DatosGenerales);
+            if (!validacionDatosGenerales.esValido)
+                return validacionDatosGenerales;
+
+            var validacionTeleproteccion = ReglasTeleproteccion.EsTeleproteccionValido(informe.Teleproteccion);
+            if (!validacionTeleproteccion.esValido)
+                return validacionTeleproteccion;
+
+            var validacionDistanciaDeFalla = ReglasDistanciaDeFalla.EsDistanciaDeFallaValido(informe.DistanciaDeFalla);
+            if (!validacionDistanciaDeFalla.esValido)
+                return validacionDistanciaDeFalla;
+
+            var validacionTiemposDeDisparo = ReglasTiemposDeDisparo.EsTiemposDeDisparoValido(informe.TiemposDeDisparo);
+            if (!validacionTiemposDeDisparo.esValido)
+                return validacionTiemposDeDisparo;
+
+            var validacionCorrientesDeFalla = ReglasCorrientesDeFalla.EsCorrientesDeFallaValido(informe.CorrientesDeFalla);
+            if (!validacionCorrientesDeFalla.esValido)
+                return validacionCorrientesDeFalla;
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+        }
+
+        //Si todos los atributos, incluso las instancias de Informe tienen todos sus atributos no nulos ni vacios
+        public static (bool esValido, string mensaje) EsInformeCompleto(Informe informe)
+        {
+
+            // Validación de las instancias de Informe utilizando las reglas específicas de cada entidad
+
+            var validacionDatosDeLinea = ReglasDatosDeLinea.EsDatosDeLineaCompleto(informe.DatosDeLinea);
+            if (!validacionDatosDeLinea.esValido)
+                return validacionDatosDeLinea;
+
+            var validacionDatosGenerales = ReglasDatosGenerales.EsDatosGeneralesCompleto(informe.DatosGenerales);
+            if (!validacionDatosGenerales.esValido)
+                return validacionDatosGenerales;
+
+            var validacionTeleproteccion = ReglasTeleproteccion.EsTeleproteccionCompleto(informe.Teleproteccion);
+            if (!validacionTeleproteccion.esValido)
+                return validacionTeleproteccion;
+
+            var validacionDistanciaDeFalla = ReglasDistanciaDeFalla.EsDistanciaDeFallaCompleto(informe.DistanciaDeFalla);
+            if (!validacionDistanciaDeFalla.esValido)
+                return validacionDistanciaDeFalla;
+
+            var validacionTiemposDeDisparo = ReglasTiemposDeDisparo.EsTiemposDeDisparoCompleto(informe.TiemposDeDisparo);
+            if (!validacionTiemposDeDisparo.esValido)
+                return validacionTiemposDeDisparo;
+
+            var validacionCorrientesDeFalla = ReglasCorrientesDeFalla.EsCorrientesDeFallaCompleto(informe.CorrientesDeFalla);
+            if (!validacionCorrientesDeFalla.esValido)
+                return validacionCorrientesDeFalla;
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+
+        }
+
+        // Método para cambiar el estado del informe a "actualizado"
+        public static void CambiarEstadoAConfirmado(Informe informe)
+        {            
+            informe.Estado = 1;
+        }
+
+        public static void CambiarTodosLosInformesAPendientes(IEnumerable<Informe> informes)
+        {
+            foreach (var informe in informes)
+            {
+                informe.Estado = 0;
+            }
+        }
+
+    }
+}

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasTeleproteccion.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasTeleproteccion.cs
@@ -1,0 +1,48 @@
+using ICE.Capa_Dominio.Modelos;
+
+namespace ICE.Capa_Dominio.ReglasDeNegocio
+{
+    public static class ReglasTeleproteccion
+    {
+        public static (bool esValido, string mensaje) EsTeleproteccionValido(Teleproteccion teleproteccion)
+        {
+            if (teleproteccion == null)
+            {
+                return (false, "La teleprotección no debe ser nula.");
+            }
+
+            // Validación del Id
+            if (teleproteccion.Id <= 0)
+            {
+                return (false, "El ID de teleprotección debe ser mayor que cero.");
+            }
+            
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+        }
+
+        public static (bool esValido, string mensaje) EsTeleproteccionCompleto(Teleproteccion teleproteccion)
+        {
+            // Validación del campo TX_TEL
+            if (string.IsNullOrWhiteSpace(teleproteccion.TX_TEL))
+            {
+                return (false, "El campo TX_TEL no debe estar vacío.");
+            }
+
+            // Validación del campo RX_TEL
+            if (string.IsNullOrWhiteSpace(teleproteccion.RX_TEL))
+            {
+                return (false, "El campo RX_TEL no debe estar vacío.");
+            }
+
+            // Validación del campo TiempoMPLS
+            if (string.IsNullOrWhiteSpace(teleproteccion.TiempoMPLS))
+            {
+                return (false, "El campo TiempoMPLS no debe estar vacío.");
+            }
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+        }
+    }
+}

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasTiemposDeDisparo.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasTiemposDeDisparo.cs
@@ -1,0 +1,55 @@
+using ICE.Capa_Dominio.Modelos;
+
+namespace ICE.Capa_Dominio.ReglasDeNegocio
+{
+    public static class ReglasTiemposDeDisparo
+    {
+        public static (bool esValido, string mensaje) EsTiemposDeDisparoValido(TiemposDeDisparo tiemposDeDisparo)
+        {
+            if (tiemposDeDisparo == null)
+            {
+                return (false, "Los tiempos de disparo no deben ser nulos.");
+            }
+
+            // Validación del Id
+            if (tiemposDeDisparo.Id <= 0)
+            {
+                return (false, "El ID de tiempos de disparo debe ser mayor que cero.");
+            }
+            
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+        }
+
+        public static (bool esValido, string mensaje) EsTiemposDeDisparoCompleto(TiemposDeDisparo tiemposDeDisparo)
+        {
+
+            // Validación del campo R
+            if (string.IsNullOrWhiteSpace(tiemposDeDisparo.R))
+            {
+                return (false, "El valor de R no debe estar vacío.");
+            }
+
+            // Validación del campo S
+            if (string.IsNullOrWhiteSpace(tiemposDeDisparo.S))
+            {
+                return (false, "El valor de S no debe estar vacío.");
+            }
+
+            // Validación del campo T
+            if (string.IsNullOrWhiteSpace(tiemposDeDisparo.T))
+            {
+                return (false, "El valor de T no debe estar vacío.");
+            }
+
+            // Validación del campo Reserva
+            if (string.IsNullOrWhiteSpace(tiemposDeDisparo.Reserva))
+            {
+                return (false, "El valor de Reserva no debe estar vacío.");
+            }
+
+            // Si todas las validaciones pasan
+            return (true, string.Empty);
+        }
+    }
+}

--- a/Backend/reporteria-ice-api/Controllers/CausaController.cs
+++ b/Backend/reporteria-ice-api/Controllers/CausaController.cs
@@ -1,0 +1,112 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using Microsoft.AspNetCore.Mvc;
+using reporteria_ice_api.DTOs;
+using reporteria_ice_api.Utilitarios;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace reporteria_ice_api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class CausaController : ControllerBase
+    {
+        private readonly IGestionarCausaCN _gestionarCausaCN;
+
+        public CausaController(IGestionarCausaCN gestionarCausaCN)
+        {
+            _gestionarCausaCN = gestionarCausaCN;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<bool>> RegistrarCausa(CausaDTO causaDTO)
+        {
+            try
+            {
+                var causa = CausaDTOMapper.ConvertirDTOACausa(causaDTO);
+                var respuesta = await _gestionarCausaCN.RegistrarCausa(causa);
+                return Ok(respuesta);
+            }
+            catch (Exception e)
+            {
+                return BadRequest(e.Message);
+            }
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<CausaDTO>>> ObtenerTodasLasCausas()
+        {
+            try
+            {
+                var causas = await _gestionarCausaCN.ObtenerTodasLasCausas();
+                var causasDTO = CausaDTOMapper.ConvertirListaDeCausasADTO(causas);
+                return Ok(causasDTO.ToList());
+            }
+            catch (Exception e)
+            {
+                return BadRequest(e.Message);
+            }
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<CausaDTO>> ObtenerCausa(int id)
+        {
+            try
+            {
+                var causa = await _gestionarCausaCN.ObtenerCausaPorId(id);
+                if (causa == null)
+                {
+                    return NotFound("Causa no encontrada.");
+                }
+                return Ok(CausaDTOMapper.ConvertirCausaADTO(causa));
+            }
+            catch (Exception e)
+            {
+                return BadRequest(e.Message);
+            }
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> EditarCausa(int id, CausaDTO causaDTO)
+        {
+            try
+            {
+                var causa = CausaDTOMapper.ConvertirDTOACausa(causaDTO);
+                var respuesta = await _gestionarCausaCN.ActualizarCausa(id, causa);
+
+                if (!respuesta)
+                {
+                    return BadRequest("Error al actualizar la causa.");
+                }
+
+                return Ok(respuesta);
+            }
+            catch (Exception e)
+            {
+                return BadRequest(e.Message);
+            }
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> EliminarCausa(int id)
+        {
+            try
+            {
+                var respuesta = await _gestionarCausaCN.EliminarCausa(id);
+
+                if (!respuesta)
+                {
+                    return BadRequest("Error al eliminar la causa.");
+                }
+
+                return Ok(respuesta);
+            }
+            catch (Exception e)
+            {
+                return BadRequest(e.Message);
+            }
+        }
+    }
+}

--- a/Backend/reporteria-ice-api/DTOs/CausaDTO.cs
+++ b/Backend/reporteria-ice-api/DTOs/CausaDTO.cs
@@ -1,0 +1,8 @@
+namespace reporteria_ice_api.DTOs
+{
+    public class CausaDTO
+    {
+        public int Id { get; set; }
+        public string Descripcion { get; set; }
+    }
+}

--- a/Backend/reporteria-ice-api/Utilitarios/CausaDTOMapper.cs
+++ b/Backend/reporteria-ice-api/Utilitarios/CausaDTOMapper.cs
@@ -1,0 +1,36 @@
+using ICE.Capa_Dominio.Modelos;
+using reporteria_ice_api.DTOs;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace reporteria_ice_api.Utilitarios
+{
+    public static class CausaDTOMapper
+    {
+        // Convierte de CausaDTO a Causa
+        public static Causa ConvertirDTOACausa(CausaDTO causaDTO)
+        {
+            return new Causa
+            {
+                Id = causaDTO.Id,
+                Descripcion = causaDTO.Descripcion
+            };
+        }
+
+        // Convierte de Causa a CausaDTO
+        public static CausaDTO ConvertirCausaADTO(Causa causa)
+        {
+            return new CausaDTO
+            {
+                Id = causa.Id,
+                Descripcion = causa.Descripcion
+            };
+        }
+
+        // Convierte una lista de Causa a una lista de CausaDTO
+        public static IEnumerable<CausaDTO> ConvertirListaDeCausasADTO(IEnumerable<Causa> causas)
+        {
+            return causas.Select(causa => ConvertirCausaADTO(causa)).ToList();
+        }
+    }
+}


### PR DESCRIPTION
1. Se definen las reglas de negocio para las siguientes clases:

- DatosDeLinea
- DatosGenerales
- Teleproteccion
- DistanciaDeFalla
- TiemposDeDisparo
- CorrientesDeFalla

2. Se realizan modificaciones y ajustes a las reglas de negocio de la clase Informe para usar las de sus instancia atributos

3.Se implementa la funcionalidad de revisión, verificación y actualización de los estados de los informes, dependiendo de si existe al menos uno con datos no nulos.

4. Se crean las siguientes clases:

- CausaController
- CausaDTO
- CausaDTOMapper

5.Se agrega el método Task<IEnumerable<int>> ObtenerIdsInformesDeReporte(int informeId); en GestionarReporteCN e IGestionarReporteCN para obtener los IDs de los informes asociados a un reporte.

6. Se integran los métodos Task VerificarEstadoInformesAsociados(int informeId);, Task<bool> VerificarInformesCompletosAsociados(int informeId); y Task<bool> ActualizarEstadosDeInformesAPendiente(int informeId); en IGestionarReporteConInformesService y GestionarReporteConInformesService. Estos métodos permiten consultar, verificar, actualizar e insertar informes relacionados con Reporte.

7. Se añade el método Task<IEnumerable<int>> ObtenerIdsInformesDeReporte(int informeId); en IGestionarReporteDA y GestionarReporteDA para obtener los IDs de informes asociados a un informe.

8. Se modifica el método Task<bool> ActualizarInforme(Informe informe) de GestionarInformeCN e IGestionarInformeCN. Ahora, cada vez que se actualiza un reporte, verifica si los demás informes hermanos asociados al mismo reporte están en estado 1 (actualizado/confirmado) y también si están completos o al menos uno de ellos.

9. Se ajustan las instancias de GestionarReporteConInformesService para que ya no dependan de GestionarInforme, permitiendo ahora el uso de los métodos de GestionarInformeDA para acceder y manipular las tablas de InformeDA.

