### PR TITLE
Proyecto de Tests con NUnit, Agregado de Validaciones a Reglas de Neg…

### DIFF
--- a/Backend/ICE.Capa_Logica/CU/GestionarReporteConInformesService.cs
+++ b/Backend/ICE.Capa_Logica/CU/GestionarReporteConInformesService.cs
@@ -49,6 +49,10 @@ namespace ICE.Capa_Negocios.CU
         {
             try
             {
+                if (!ReglasReporte.ReporteInicialValido(subestacionIds, lineaTransmisionId, reporte).esValido) return false;
+                //metodo para compribar que el supervisorId exista y el tecnico tambien
+
+
                 //lista de informes
                 List<Informe> informes = new List<Informe>();
 

--- a/Backend/ICE.Capa_Logica/CU/GestionarUsuarioCN.cs
+++ b/Backend/ICE.Capa_Logica/CU/GestionarUsuarioCN.cs
@@ -1,6 +1,7 @@
 ﻿using ICE.Capa_Dominio.Modelos;
 using ICE.Capa_Negocios.Interfaces.Capa_Datos;
 using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using ICE.Capa_Dominio.ReglasDeNegocio;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 
@@ -17,6 +18,11 @@ namespace ICE.Capa_Negocios.CU
 
         public async Task<int> RegistrarUsuario(Usuario usuario)
         {
+            var validacionUsuario = ReglasUsuario.EsUsuarioValido(usuario);
+            if (!validacionUsuario.esValido)
+            {
+                return 0;
+            }
             return await _gestionarUsuarioDA.RegistrarUsuario(usuario);
         }
 
@@ -32,6 +38,11 @@ namespace ICE.Capa_Negocios.CU
 
         public async Task<bool> ActualizarUsuario(int id, Usuario usuario)
         {
+            var validacionUsuario = ReglasUsuario.EsUsuarioValido(usuario);
+            if (!validacionUsuario.esValido)
+            {
+                return false;
+            }
             return await _gestionarUsuarioDA.ActualizarUsuario(id, usuario);
         }
 

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasLineaTransmision.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasLineaTransmision.cs
@@ -8,9 +8,9 @@ namespace ICE.Capa_Dominio.ReglasDeNegocio
         public static (bool esValido, string mensaje) EsLineaTransmisionValida(LineaTransmision lineaTransmision)
         {
             // Validación del NombreUbicacion
-            if (string.IsNullOrEmpty(lineaTransmision.NombreUbicacion))
+            if (string.IsNullOrWhiteSpace(lineaTransmision.NombreUbicacion))
             {
-                return (false, "El nombre de la ubicación no puede estar vacío.");
+                return (false, "El nombre de la ubicación no puede estar vacío o solo contener espacios en blanco.");
             }
 
             if (lineaTransmision.NombreUbicacion.Length > 100)
@@ -18,10 +18,14 @@ namespace ICE.Capa_Dominio.ReglasDeNegocio
                 return (false, "El nombre de la ubicación no puede exceder los 100 caracteres.");
             }
 
-            // Validación del Identificador
-            if (lineaTransmision.Identificador.Length <= 0)
+            if (string.IsNullOrWhiteSpace(lineaTransmision.Identificador))
             {
-                return (false, "El identificador de la línea de transmisión debe ser mayor que cero.");
+                return (false, "El identificador de la subestación no puede estar vacío o solo contener espacios en blanco.");
+            }
+            
+            if (lineaTransmision.Identificador.Length < 3 || lineaTransmision.Identificador.Length > 20)
+            {
+                return (false, "El identificador de la subestación debe tener entre 3 y 20 caracteres.");
             }
 
             return (true, string.Empty); 

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasReporte.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasReporte.cs
@@ -167,5 +167,36 @@ namespace ICE.Capa_Dominio.ReglasDeNegocio
         }
 
 
+        //Nuevo metodo para validar los id de las subestacion y la linea de transmision
+        public static (bool esValido, string mensaje) ReporteInicialValido(List<int> subestacionIds, int lineaId, Reporte reporte)
+        {
+
+            foreach (int id in subestacionIds)
+            {
+                if(id <= 0)
+                {
+                    return (false, "El ID de la línea de transmisión proporcionada no es válido.");
+                }
+            }
+
+            if (lineaId <= 0)
+            {
+                return (false, "El ID de la línea de transmisión proporcionada no es válido.");
+            }
+
+            if (reporte.UsuarioSupervisorId <= 0)
+            {
+                return (false, "El ID del supervisor proporcionado no es válido.");
+            }
+
+            if (reporte.TecnicoLineaId <= 0)
+            {
+                return (false, "El ID del técnico de línea proporcionado no es válido.");
+            }
+
+
+
+            return (true, string.Empty);
+        }
     }
 }

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasSubestacion.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasSubestacion.cs
@@ -8,23 +8,26 @@ namespace ICE.Capa_Dominio.ReglasDeNegocio
         public static (bool esValido, string mensaje) EsSubestacionValida(Subestacion subestacion)
         {
             // Validación del NombreUbicacion
-            if (string.IsNullOrEmpty(subestacion.NombreUbicacion))
+            if (string.IsNullOrWhiteSpace(subestacion.NombreUbicacion))
             {
-                return (false, "El nombre de la ubicación no puede estar vacío.");
+                return (false, "El nombre de la ubicación no puede estar vacío o solo contener espacios en blanco.");
             }
 
             if (subestacion.NombreUbicacion.Length > 100)
             {
                 return (false, "El nombre de la ubicación no puede exceder los 100 caracteres.");
             }
-
-            // Validación del Identificador
-            if (subestacion.Identificador.Length <= 0)
+            
+            if (string.IsNullOrWhiteSpace(subestacion.Identificador))
             {
-                return (false, "El identificador de la subestación debe ser mayor que cero.");
+                return (false, "El identificador de la subestación no puede estar vacío o solo contener espacios en blanco.");
             }
 
-            // Validación del UnidadRegionalId
+            if (subestacion.Identificador.Length < 3 || subestacion.Identificador.Length > 20)
+            {
+                return (false, "El identificador de la subestación debe tener entre 3 y 20 caracteres.");
+            }
+            
             if (subestacion.UnidadRegionalId <= 0)
             {
                 return (false, "El ID de la unidad regional debe ser mayor que cero.");

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasUnidadRegional.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasUnidadRegional.cs
@@ -9,9 +9,9 @@ namespace ICE.Capa_Dominio.ReglasDeNegocio
         {
 
             // Validación del NombreUbicacion
-            if (string.IsNullOrEmpty(unidadRegional.NombreUbicacion))
+            if (string.IsNullOrWhiteSpace(unidadRegional.NombreUbicacion))
             {
-                return (false, "El nombre de la ubicación no puede estar vacío.");
+                return (false, "El nombre de la ubicación no puede estar vacío o solo contener espacios en blanco.");
             }
 
             if (unidadRegional.NombreUbicacion.Length > 100)
@@ -19,12 +19,16 @@ namespace ICE.Capa_Dominio.ReglasDeNegocio
                 return (false, "El nombre de la ubicación no puede exceder los 100 caracteres.");
             }
 
-            // Validación del Identificador
-            if (unidadRegional.Identificador.Length <= 0)
+            if (string.IsNullOrWhiteSpace(unidadRegional.Identificador))
             {
-                return (false, "El identificador de la unidad regional debe ser mayor que cero.");
+                return (false, "El identificador de la subestación no puede estar vacío o solo contener espacios en blanco.");
             }
 
+            if (unidadRegional.Identificador.Length < 3 || unidadRegional.Identificador.Length > 20)
+            {
+                return (false, "El identificador de la subestación debe tener entre 3 y 20 caracteres.");
+            }
+            
             return (true, string.Empty); 
         }
 

--- a/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasUsuario.cs
+++ b/Backend/ICE.Capa_Negocios/ReglasDeNegocio/ReglasUsuario.cs
@@ -31,13 +31,15 @@ namespace ICE.Capa_Dominio.ReglasDeNegocio
                 return (false, "La contraseña debe tener al menos 8 caracteres.");
             }
 
-            if (usuario.Identificador.Length <= 0)
+            //Se modifica esta relga en especifico, ya que se validaba como int el identificador
+            if (string.IsNullOrWhiteSpace(usuario.Identificador))
             {
-                Console.WriteLine("El identificador debe ser mayor que cero.");
-                return (false, "El identificador debe ser mayor que cero.");
+                Console.WriteLine("El identificador no puede estar vacío o solo contener espacios en blanco.");
+                return (false, "El identificador no puede estar vacío o solo contener espacios en blanco.");
             }
 
-            if (usuario.Rol.Length <= 0)
+            //Se modifica esta relga en especifico, ya que se validaba como int el rol
+            if (string.IsNullOrWhiteSpace(usuario.Rol))
             {
                 Console.WriteLine("El rol no es válido.");
                 return (false, "El rol no es válido.");
@@ -61,7 +63,11 @@ namespace ICE.Capa_Dominio.ReglasDeNegocio
                 return (false, "El apellido no puede exceder los 100 caracteres.");
             }
 
-            if (!string.IsNullOrEmpty(usuario.Correo) && !usuario.Correo.Contains("@"))
+            bool tieneArroba = usuario.Correo.Contains("@");
+            bool tienePunto = usuario.Correo.Contains(".");
+            bool correoInvalido = !tieneArroba || !tienePunto;
+
+            if (!string.IsNullOrEmpty(usuario.Correo) && correoInvalido)
             {
                 Console.WriteLine("El formato del correo es incorrecto.");
                 return (false, "El formato del correo es incorrecto.");

--- a/Backend/ICE_Test/ICE_Test.csproj
+++ b/Backend/ICE_Test/ICE_Test.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />  
+  </ItemGroup>
+	
+    <ItemGroup>
+        <ProjectReference Include="..\Capa_Datos\ICE.Capa_Datos.csproj" />
+        <ProjectReference Include="..\Capa_Logica\ICE.Capa_Negocios.csproj" />
+        <ProjectReference Include="..\Capa_Negocios\ICE.Capa_Dominio.csproj" />
+	    <ProjectReference Include="..\Capa_Integracion\ICE.Capa_Integracion.csproj" />
+    </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>	    
+
+</Project>

--- a/Backend/ICE_Test/TestsUnitarios/GestionarLineaTransmisionTest/ActualizarLineaTransmisionTest.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarLineaTransmisionTest/ActualizarLineaTransmisionTest.cs
@@ -1,0 +1,84 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class ActualizarLineaTransmisionTest
+    {
+        private Mock<IGestionarLineasTransmisionDA> _mockLineaTransmisionDA;
+        private GestionarLineasTransmisionCN _gestionarLineaTransmisionCN;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Se instancia la clase de base de datos asociada para manipular sus resultados
+            _mockLineaTransmisionDA = new Mock<IGestionarLineasTransmisionDA>();
+            // Clase de la cual se probarán los métodos
+            _gestionarLineaTransmisionCN = new GestionarLineasTransmisionCN(_mockLineaTransmisionDA.Object);
+        }
+
+        [Test]
+        public async Task ActualizarLineaTransmisionValida()
+        {
+            // Arrange
+            var lineaTransmision = new LineaTransmision
+            {
+                NombreUbicacion = "Ubicacion Actualizada",
+                Identificador = "LT-001"
+            };
+            _mockLineaTransmisionDA.Setup(da => da.ActualizarLineaTransmision(1, lineaTransmision)).ReturnsAsync(true);
+
+            // Act
+            var resultado = await _gestionarLineaTransmisionCN.ActualizarLineaTransmision(1, lineaTransmision);
+
+            // Assert
+            Assert.IsTrue(resultado, "La actualización debería ser exitosa para una línea de transmisión válida.");
+            _mockLineaTransmisionDA.Verify(da => da.ActualizarLineaTransmision(1, lineaTransmision), Times.Once);
+        }
+
+        [Test]
+        public async Task ActualizarLineaTransmisionInvalida_NombreUbicacionInvalido()
+        {
+            var lineasInvalidas = new List<LineaTransmision>
+            {
+                new LineaTransmision { NombreUbicacion = "", Identificador = "LT-001" },
+                new LineaTransmision { NombreUbicacion = " ", Identificador = "LT-123" },
+                new LineaTransmision { NombreUbicacion = "   ", Identificador = "LT-001" },
+                new LineaTransmision { NombreUbicacion = new string('a', 101), Identificador = "LT-001" }
+            };
+
+            foreach (var linea in lineasInvalidas)
+            {
+                var resultado = await _gestionarLineaTransmisionCN.ActualizarLineaTransmision(1, linea);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {linea}");
+                _mockLineaTransmisionDA.Verify(da => da.ActualizarLineaTransmision(It.IsAny<int>(), It.IsAny<LineaTransmision>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task ActualizarLineaTransmisionInvalida_IdentificadorInvalido()
+        {
+            var lineasInvalidas = new List<LineaTransmision>
+            {
+                new LineaTransmision { NombreUbicacion = "Orosi", Identificador = "" },
+                new LineaTransmision { NombreUbicacion = "Tapanti", Identificador = " " },
+                new LineaTransmision { NombreUbicacion = "Rio Macho", Identificador = "   " },
+                new LineaTransmision { NombreUbicacion = "Rio Macho", Identificador = "Ca" },
+                new LineaTransmision { NombreUbicacion = "Quetzal", Identificador = new string('a', 21) }
+            };
+
+            foreach (var linea in lineasInvalidas)
+            {
+                var resultado = await _gestionarLineaTransmisionCN.ActualizarLineaTransmision(1, linea);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {linea}");
+                _mockLineaTransmisionDA.Verify(da => da.ActualizarLineaTransmision(It.IsAny<int>(), It.IsAny<LineaTransmision>()), Times.Never);
+            }
+        }
+    }
+}

--- a/Backend/ICE_Test/TestsUnitarios/GestionarLineaTransmisionTest/RegistrarLineaTransmisionTest.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarLineaTransmisionTest/RegistrarLineaTransmisionTest.cs
@@ -1,0 +1,87 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using ICE.Capa_Dominio.ReglasDeNegocio;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class RegistrarLineaTransmisionTest
+    {
+        private Mock<IGestionarLineasTransmisionDA> _mockLineaTransmisionDA;
+        private GestionarLineasTransmisionCN _gestionarLineaTransmisionCN;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Se instancia la clase de base de datos asociada para manipular sus resultados
+            _mockLineaTransmisionDA = new Mock<IGestionarLineasTransmisionDA>();
+            // Clase de la cual se probarán los métodos
+            _gestionarLineaTransmisionCN = new GestionarLineasTransmisionCN(_mockLineaTransmisionDA.Object);
+        }
+
+        [Test]
+        public async Task RegistrarLineaTransmisionValida()
+        {
+            // Arrange
+            var lineaTransmision = new LineaTransmision
+            {
+                NombreUbicacion = "Ubicacion Principal",
+                Identificador = "LT-001"
+            };
+            _mockLineaTransmisionDA.Setup(da => da.RegistrarLineaTransmision(lineaTransmision)).ReturnsAsync(true);
+
+            // Act
+            var resultado = await _gestionarLineaTransmisionCN.RegistrarLineaTransmision(lineaTransmision);
+
+            // Assert
+            Assert.IsTrue(resultado);
+            _mockLineaTransmisionDA.Verify(da => da.RegistrarLineaTransmision(lineaTransmision), Times.Once);
+        }
+
+        [Test]
+        public async Task RegistrarLineaTransmisionInvalida_NombreUbicacionInvalido()
+        {
+            var lineasInvalidas = new List<LineaTransmision>
+            {
+                new LineaTransmision { NombreUbicacion = "", Identificador = "LT-001" },
+                new LineaTransmision { NombreUbicacion = " ", Identificador = "LT-123" },
+                new LineaTransmision { NombreUbicacion = "   ", Identificador = "LT-001" },
+                new LineaTransmision { NombreUbicacion = new string('a', 101), Identificador = "LT-001" }
+            };
+
+            foreach (var linea in lineasInvalidas)
+            {
+                var resultado = await _gestionarLineaTransmisionCN.RegistrarLineaTransmision(linea);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {linea}");
+                _mockLineaTransmisionDA.Verify(da => da.RegistrarLineaTransmision(It.IsAny<LineaTransmision>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task RegistrarLineaTransmisionInvalida_IdentificadorInvalido()
+        {
+            var lineasInvalidas = new List<LineaTransmision>
+            {
+                new LineaTransmision { NombreUbicacion = "Orosi", Identificador = "" },
+                new LineaTransmision { NombreUbicacion = "Tapanti", Identificador = " " },
+                new LineaTransmision { NombreUbicacion = "Rio Macho", Identificador = "   " },
+                new LineaTransmision { NombreUbicacion = "Rio Macho", Identificador = "Ca" },
+                new LineaTransmision { NombreUbicacion = "Quetzal", Identificador = new string('a', 21) }
+            };
+
+            foreach (var linea in lineasInvalidas)
+            {
+                var resultado = await _gestionarLineaTransmisionCN.RegistrarLineaTransmision(linea);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {linea}");
+                _mockLineaTransmisionDA.Verify(da => da.RegistrarLineaTransmision(It.IsAny<LineaTransmision>()), Times.Never);
+            }
+        }
+        //Falta Agregar el Metodo sobre Identificador que coincide con uno de la BD
+    }
+}

--- a/Backend/ICE_Test/TestsUnitarios/GestionarReporteConInformesServiceTest/ActualizarEstadoReporteSegunInformesTest.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarReporteConInformesServiceTest/ActualizarEstadoReporteSegunInformesTest.cs
@@ -1,0 +1,411 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class ActualizarEstadoReporteSegunInformesTest
+    {
+        private Mock<IGestionarReporteDA> _mockReporteDA;
+        private Mock<IGestionarInformeDA> _mockInformeDA;        
+        private GestionarReporteConInformesService _gestionarReporteConInformesService;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockReporteDA = new Mock<IGestionarReporteDA>();
+            _mockInformeDA = new Mock<IGestionarInformeDA>();            
+            _gestionarReporteConInformesService = new GestionarReporteConInformesService(
+                _mockInformeDA.Object,
+                _mockReporteDA.Object,
+                new Mock<IGestionarTeleproteccionDA>().Object,
+                new Mock<IGestionarDistanciaDeFallaDA>().Object,
+                new Mock<IGestionarCorrientesDeFallaDA>().Object,
+                new Mock<IGestionarTiemposDeDisparoDA>().Object,
+                new Mock<IGestionarLineasTransmisionDA>().Object,
+                new Mock<IGestionarDatosDeLineaDA>().Object,
+                new Mock<IGestionarDatosGeneralesDA>().Object
+            );
+        }
+
+        [Test]
+        public async Task ActualizarEstadoReporteValidoDeSupervisor_TodosInformesConfirmadosEstado1ConDatosRequeridos()
+        {
+            //Crear reporte completo y configurar mocks
+            var reporte = CrearReporteCompleto(
+                estado: 2,
+                fechaHora: DateTime.Parse("2024-10-31T18:13:57"),
+                causas: "Falla eléctrica, Derrumbe",
+                observacionesSupervisor: "Revisión completa"
+            );  
+            var idsInformesAsociados = new List<int> { 10, 11, 12, 13 };
+            var informesMixtos = new List<Informe>
+                {
+                    CrearInformeCompleto(10, estado: 1),
+                    CrearInformeCompleto(11, estado: 1),
+                    CrearInformeCompleto(12, estado: 1),
+                    CrearInformeCompleto(13, estado: 1)
+                };
+
+            _mockReporteDA.Setup(da => da.ObtenerIdsInformesDeReporte(reporte.Id))
+                          .ReturnsAsync(idsInformesAsociados);
+
+            foreach (var informe in informesMixtos)
+            {
+                _mockInformeDA.Setup(da => da.ObtenerInformePorId(informe.Id)).ReturnsAsync(informe);
+            }
+
+            // Configurar el mock para `ActualizarReporte` para nunca llamarlo a la bd
+            _mockReporteDA.Setup(da => da.ActualizarReporte(reporte.Id, reporte)).ReturnsAsync(true);
+
+            //Prueba
+            var resultado = await _gestionarReporteConInformesService.ActualizarEstadoReporteSegunInformes(reporte);
+            
+            Assert.IsTrue(resultado);
+            Assert.AreEqual(3, reporte.Estado);
+            _mockReporteDA.Verify(da => da.ActualizarReporte(reporte.Id, reporte), Times.Once);
+        }
+
+        
+        [Test]
+        public async Task ActualizarEstadoReporteValidoDeTecnicoLinea_TodosInformesConfirmadosEstado1ConDatosRequeridos()
+        {
+            //Crear reporte completo y configurar mocks
+            var reporte = CrearReporteCompleto(
+                estado: 3,
+                fechaHora: DateTime.Parse("2024-10-31T18:13:57"),
+                causas: "Falla eléctrica, Derrumbe",
+                observacionesSupervisor: "Revisión completa"
+            );
+            var idsInformesAsociados = new List<int> { 10, 11, 12, 13 };
+            var informesMixtos = new List<Informe>
+                {
+                    CrearInformeCompleto(10, estado: 1),
+                    CrearInformeCompleto(11, estado: 1),
+                    CrearInformeCompleto(12, estado: 1),
+                    CrearInformeCompleto(13, estado: 1)
+                };
+
+            _mockReporteDA.Setup(da => da.ObtenerIdsInformesDeReporte(reporte.Id))
+                          .ReturnsAsync(idsInformesAsociados);
+
+            foreach (var informe in informesMixtos)
+            {
+                _mockInformeDA.Setup(da => da.ObtenerInformePorId(informe.Id)).ReturnsAsync(informe);
+            }
+
+            // Configurar el mock para `ActualizarReporte` para nunca llamarlo a la bd
+            _mockReporteDA.Setup(da => da.ActualizarReporte(reporte.Id, reporte)).ReturnsAsync(true);
+
+            //Prueba
+            var resultado = await _gestionarReporteConInformesService.ActualizarEstadoReporteSegunInformes(reporte);
+
+            Assert.IsTrue(resultado);
+            Assert.AreEqual(4, reporte.Estado);
+            _mockReporteDA.Verify(da => da.ActualizarReporte(reporte.Id, reporte), Times.Once);
+        }
+        
+        
+        [Test]
+        public async Task ActualizarEstadoReporteInvalidoDeSupervisor_InformesConEstado0ConDatosRequeridos()
+        {
+            //Crear reporte completo y configurar mocks
+            var reporte = CrearReporteCompleto(
+                estado: 2,
+                fechaHora: DateTime.Parse("2024-10-31T18:13:57"),
+                causas: "Falla eléctrica, Derrumbe",
+                observacionesSupervisor: "Revisión completa"
+            );
+            var idsInformesAsociados = new List<int> { 10, 11, 12, 13 };
+            var informesMixtos = new List<Informe>
+                {
+                    CrearInformeCompleto(10, estado: 0),
+                    CrearInformeCompleto(11, estado: 1),
+                    CrearInformeCompleto(12, estado: 0),
+                    CrearInformeCompleto(13, estado: 1)
+                };
+
+            _mockReporteDA.Setup(da => da.ObtenerIdsInformesDeReporte(reporte.Id))
+                          .ReturnsAsync(idsInformesAsociados);
+
+            foreach (var informe in informesMixtos)
+            {
+                _mockInformeDA.Setup(da => da.ObtenerInformePorId(informe.Id)).ReturnsAsync(informe);
+            }
+
+            // Configurar el mock para `ActualizarReporte` para nunca llamarlo a la bd
+            _mockReporteDA.Setup(da => da.ActualizarReporte(reporte.Id, reporte)).ReturnsAsync(true);
+
+            //Prueba
+            var resultado = await _gestionarReporteConInformesService.ActualizarEstadoReporteSegunInformes(reporte);
+
+            Assert.IsFalse(resultado);
+            //No cambia de estado, ya que sus informes no estan confirmados
+            Assert.AreEqual(2, reporte.Estado);
+            _mockReporteDA.Verify(da => da.ActualizarReporte(reporte.Id, reporte), Times.Never);
+        }
+        
+        [Test]
+        public async Task ActualizarEstadoReporteInvalidoDeTecnicoLinea_InformesConEstado0ConDatosRequeridos()
+        {
+            //Crear reporte completo y configurar mocks
+            var reporte = CrearReporteCompleto(
+                estado: 3,
+                fechaHora: DateTime.Parse("2024-10-31T18:13:57"),
+                causas: "Falla eléctrica, Derrumbe",
+                observacionesSupervisor: "Revisión completa"
+            );
+            var idsInformesAsociados = new List<int> { 10, 11, 12, 13 };
+            var informesMixtos = new List<Informe>
+                {
+                    CrearInformeCompleto(10, estado: 0),
+                    CrearInformeCompleto(11, estado: 0),
+                    CrearInformeCompleto(12, estado: 0),
+                    CrearInformeCompleto(13, estado: 1)
+                };
+
+            _mockReporteDA.Setup(da => da.ObtenerIdsInformesDeReporte(reporte.Id))
+                          .ReturnsAsync(idsInformesAsociados);
+
+            foreach (var informe in informesMixtos)
+            {
+                _mockInformeDA.Setup(da => da.ObtenerInformePorId(informe.Id)).ReturnsAsync(informe);
+            }
+
+            // Configurar el mock para `ActualizarReporte` para nunca llamarlo a la bd
+            _mockReporteDA.Setup(da => da.ActualizarReporte(reporte.Id, reporte)).ReturnsAsync(true);
+
+            //Prueba
+            var resultado = await _gestionarReporteConInformesService.ActualizarEstadoReporteSegunInformes(reporte);
+
+            Assert.IsFalse(resultado);
+            //No cambia de estado, ya que sus informes no estan confirmados
+            Assert.AreEqual(3, reporte.Estado);
+            _mockReporteDA.Verify(da => da.ActualizarReporte(reporte.Id, reporte), Times.Never);
+        }
+
+
+        [Test]
+        public async Task ActualizarEstadoReporteInvalidoDeSupervisor_InformesConEstado1SinDatosRequeridos()
+        {
+            //Crear reporte completo y configurar mocks
+            var reporte = CrearReporteCompleto(
+                estado: 2,
+                fechaHora: DateTime.Parse("2024-10-31T18:13:57"),
+                causas: "Falla eléctrica, Derrumbe",
+                observacionesSupervisor: null
+            );
+            var idsInformesAsociados = new List<int> { 10, 11, 12, 13 };
+            var informesMixtos = new List<Informe>
+                {
+                    CrearInformeCompleto(10, estado: 1),
+                    CrearInformeCompleto(11, estado: 1),
+                    CrearInformeCompleto(12, estado: 1),
+                    CrearInformeCompleto(13, estado: 1)
+                };
+
+            _mockReporteDA.Setup(da => da.ObtenerIdsInformesDeReporte(reporte.Id))
+                          .ReturnsAsync(idsInformesAsociados);
+
+            foreach (var informe in informesMixtos)
+            {
+                _mockInformeDA.Setup(da => da.ObtenerInformePorId(informe.Id)).ReturnsAsync(informe);
+            }
+
+            // Configurar el mock para `ActualizarReporte` para nunca llamarlo a la bd
+            _mockReporteDA.Setup(da => da.ActualizarReporte(reporte.Id, reporte)).ReturnsAsync(true);
+
+            //Prueba
+            var resultado = await _gestionarReporteConInformesService.ActualizarEstadoReporteSegunInformes(reporte);
+
+            Assert.IsFalse(resultado);
+            //No cambia de estado, ya que le faltan los datos obligatorios
+            Assert.AreEqual(2, reporte.Estado);
+            _mockReporteDA.Verify(da => da.ActualizarReporte(reporte.Id, reporte), Times.Never);
+        }
+
+
+        [Test]
+        public async Task ActualizarEstadoReporteInvalidoDeTecnicoLinea_InformesConEstado1SinDatosRequeridos()
+        {
+            //Crear reporte completo y configurar mocks
+            var reporte = CrearReporteCompleto(
+                estado: 3,
+                fechaHora: null,
+                causas: null,
+                observacionesSupervisor: "Revisión completa"
+            );
+            var idsInformesAsociados = new List<int> { 10, 11, 12, 13 };
+            var informesMixtos = new List<Informe>
+                {
+                    CrearInformeCompleto(10, estado: 1),
+                    CrearInformeCompleto(11, estado: 1),
+                    CrearInformeCompleto(12, estado: 1),
+                    CrearInformeCompleto(13, estado: 1)
+                };
+
+            _mockReporteDA.Setup(da => da.ObtenerIdsInformesDeReporte(reporte.Id))
+                          .ReturnsAsync(idsInformesAsociados);
+
+            foreach (var informe in informesMixtos)
+            {
+                _mockInformeDA.Setup(da => da.ObtenerInformePorId(informe.Id)).ReturnsAsync(informe);
+            }
+
+            // Configurar el mock para `ActualizarReporte` para nunca llamarlo a la bd
+            _mockReporteDA.Setup(da => da.ActualizarReporte(reporte.Id, reporte)).ReturnsAsync(true);
+
+            //Prueba
+            var resultado = await _gestionarReporteConInformesService.ActualizarEstadoReporteSegunInformes(reporte);
+
+            Assert.IsFalse(resultado);
+            //No cambia de estado, ya que sus informes no estan confirmados
+            Assert.AreEqual(3, reporte.Estado);
+            _mockReporteDA.Verify(da => da.ActualizarReporte(reporte.Id, reporte), Times.Never);
+        }
+
+
+        [Test]
+        public async Task ActualizarEstadoReporteValidoDeTecnicoProteccion_InformesConEstado1()
+        {
+            //Crear reporte completo y configurar mocks
+            var reporte = CrearReporteCompleto(
+                estado: 1,
+                fechaHora: null,
+                causas: null,
+                observacionesSupervisor: null
+            );
+            var idsInformesAsociados = new List<int> { 10, 11, 12, 13 };
+            var informesMixtos = new List<Informe>
+                {
+                    CrearInformeCompleto(10, estado: 1),
+                    CrearInformeCompleto(11, estado: 1),
+                    CrearInformeCompleto(12, estado: 1),
+                    CrearInformeCompleto(13, estado: 1)
+                };
+
+            _mockReporteDA.Setup(da => da.ObtenerIdsInformesDeReporte(reporte.Id))
+                          .ReturnsAsync(idsInformesAsociados);
+
+            foreach (var informe in informesMixtos)
+            {
+                _mockInformeDA.Setup(da => da.ObtenerInformePorId(informe.Id)).ReturnsAsync(informe);
+            }
+
+            // Configurar el mock para `ActualizarReporte` para nunca llamarlo a la bd
+            _mockReporteDA.Setup(da => da.ActualizarReporte(reporte.Id, reporte)).ReturnsAsync(true);
+
+            //Prueba
+            var resultado = await _gestionarReporteConInformesService.ActualizarEstadoReporteSegunInformes(reporte);
+
+            Assert.IsTrue(resultado);
+            //No cambia de estado, ya que sus informes no estan confirmados
+            Assert.AreEqual(2, reporte.Estado);
+            _mockReporteDA.Verify(da => da.ActualizarReporte(reporte.Id, reporte), Times.Once);
+        }
+
+        // Método auxiliar para crear un informe con estado y datos específicos
+        private Informe CrearInformeCompleto(int id, int estado)
+        {
+            return new Informe
+            {
+                Id = id,
+                Estado = estado,
+                Tipo = 2,
+                SubestacionId = 1,
+                LineaTransmisionId = 1,
+                DatosDeLineaId = id,
+                DatosDeLinea = new DatosDeLinea
+                {
+                    Id = id,
+                    OT = "OT-12345",
+                    Aviso = "Aviso-001",
+                    SAP = "SAP-56789",
+                    Distancia = "20 km",
+                    Funcion = "Función de protección",
+                    Zona = "Zona Norte"
+                },
+                DatosGeneralesId = id,
+                DatosGenerales = new DatosGenerales
+                {
+                    Id = id,
+                    Evento = "Falla en línea de transmisión",
+                    Fecha = DateTime.Parse("2024-10-31T18:13:57.837"),
+                    Hora = TimeSpan.Parse("08:30:00"),
+                    Subestacion = "Subestación Norte",
+                    LT = "LT-456",
+                    Equipo = "Equipo A"
+                },
+                TeleproteccionId = id,
+                Teleproteccion = new Teleproteccion
+                {
+                    Id = id,
+                    TX_TEL = "TX-100",
+                    RX_TEL = "RX-100",
+                    TiempoMPLS = "200 ms"
+                },
+                DistanciaDeFallaId = id,
+                DistanciaDeFalla = new DistanciaDeFalla
+                {
+                    Id = id,
+                    DistanciaKM = "15 km",
+                    DistanciaPorcentaje = "75%",
+                    DistanciaReportada = "Distancia Reportada - 14 km",
+                    DistanciaDobleTemporal = "Distancia doble temporal - 10 km",
+                    Error = "0.5%",
+                    Error_Doble = "1%"
+                },
+                TiemposDeDisparoId = id,
+                TiemposDeDisparo = new TiemposDeDisparo
+                {
+                    Id = id,
+                    R = "30 ms",
+                    S = "40 ms",
+                    T = "50 ms",
+                    Reserva = "10 ms"
+                },
+                CorrientesDeFallaId = id,
+                CorrientesDeFalla = new CorrientesDeFalla
+                {
+                    Id = id,
+                    RealIR = "500 A",
+                    RealIS = "600 A",
+                    RealIT = "700 A",
+                    AcumuladaR = "1500 A",
+                    AcumuladaS = "1600 A",
+                    AcumuladaT = "1700 A"
+                }
+            };
+        }
+
+
+
+        // Método auxiliar para crear un reporte con estado específico
+        private Reporte CrearReporteCompleto(int estado, DateTime? fechaHora, string causas, string observacionesSupervisor)
+        {
+            return new Reporte
+            {
+                Id = 1,
+                Estado = estado,
+                MapaDeDescargas = null,
+                Observaciones = observacionesSupervisor,
+                Evidencia = null,
+                ObservacionesTecnicoLinea = "Observación del técnico de línea",
+                Causas = causas,
+                FechaHora = fechaHora,
+                InformeV1Id = 10,
+                InformeV2Id = 11,
+                InformeV3Id = 12,
+                InformeV4Id = 13,
+                UsuarioSupervisorId = 1,
+                TecnicoLineaId = 2
+            };
+        }
+    }
+}

--- a/Backend/ICE_Test/TestsUnitarios/GestionarReporteConInformesServiceTest/VerificarInformesCompletosAsociados.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarReporteConInformesServiceTest/VerificarInformesCompletosAsociados.cs
@@ -1,0 +1,570 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class VerificarInformesCompletosAsociadosTest
+    {
+        private Mock<IGestionarReporteDA> _mockReporteDA;
+        private Mock<IGestionarInformeDA> _mockInformeDA;
+        private GestionarReporteConInformesService _gestionarReporteConInformesService;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockReporteDA = new Mock<IGestionarReporteDA>();
+            _mockInformeDA = new Mock<IGestionarInformeDA>();
+            _gestionarReporteConInformesService = new GestionarReporteConInformesService(
+                _mockInformeDA.Object,
+                _mockReporteDA.Object,
+                new Mock<IGestionarTeleproteccionDA>().Object,
+                new Mock<IGestionarDistanciaDeFallaDA>().Object,
+                new Mock<IGestionarCorrientesDeFallaDA>().Object,
+                new Mock<IGestionarTiemposDeDisparoDA>().Object,
+                new Mock<IGestionarLineasTransmisionDA>().Object,
+                new Mock<IGestionarDatosDeLineaDA>().Object,
+                new Mock<IGestionarDatosGeneralesDA>().Object
+            );
+        }
+
+
+        [Test]
+        public async Task ActualizarReporteValido_InformesConDatosCompletos()
+        {
+            //Datos que usaran los metodos DA dentro de GestionarReporteConIformesService
+            int informe1Id = 10;
+            int informe2Id = 11;
+            var idsInformesAsociados = new List<int> { informe1Id, informe2Id };
+
+
+            //Informes
+            var informe1Completo = new Informe
+            {
+                Id = 10,
+                Tipo = 2,
+                SubestacionId = 1,
+                LineaTransmisionId = 1,
+                DatosDeLinea = new DatosDeLinea
+                {
+                    Id = 10,
+                    OT = "OT-12345",
+                    Aviso = "Aviso-001",
+                    SAP = "SAP-56789",
+                    Distancia = "20 km",
+                    Funcion = "Función de protección",
+                    Zona = "Zona Norte"
+                },
+                DatosGenerales = new DatosGenerales
+                {
+                    Id = 10,
+                    Evento = "Falla en línea de transmisión",
+                    Fecha = DateTime.Parse("2024-10-31T18:13:57.837"),
+                    Hora = TimeSpan.Parse("08:30:00"),
+                    Subestacion = "Subestación Norte",
+                    LT = "LT-456",
+                    Equipo = "Equipo A"
+                },
+                Teleproteccion = new Teleproteccion
+                {
+                    Id = 10,
+                    TX_TEL = "TX-100",
+                    RX_TEL = "RX-100",
+                    TiempoMPLS = "200 ms"
+                },
+                DistanciaDeFalla = new DistanciaDeFalla
+                {
+                    Id = 10,
+                    DistanciaKM = "15 km",
+                    DistanciaPorcentaje = "75%",
+                    DistanciaReportada = "Distancia Reportada - 14 km",
+                    DistanciaDobleTemporal = "Distancia doble temporal - 10 km",
+                    Error = "0.5%",
+                    Error_Doble = "1%"
+                },
+                TiemposDeDisparo = new TiemposDeDisparo
+                {
+                    Id = 10,
+                    R = "30 ms",
+                    S = "40 ms",
+                    T = "50 ms",
+                    Reserva = "10 ms"
+                },
+                CorrientesDeFalla = new CorrientesDeFalla
+                {
+                    Id = 10,
+                    RealIR = "500 A",
+                    RealIS = "600 A",
+                    RealIT = "700 A",
+                    AcumuladaR = "1500 A",
+                    AcumuladaS = "1600 A",
+                    AcumuladaT = "1700 A"
+                },
+                Estado = 1
+            };
+
+            //Informes
+            var informe2Completo = new Informe
+            {
+                Id = 10,
+                Tipo = 2,
+                SubestacionId = 1,
+                LineaTransmisionId = 1,
+                DatosDeLinea = new DatosDeLinea
+                {
+                    Id = 10,
+                    OT = "OT-12345",
+                    Aviso = "Aviso-001",
+                    SAP = "SAP-56789",
+                    Distancia = "20 km",
+                    Funcion = "Función de protección",
+                    Zona = "Zona Norte"
+                },
+                DatosGenerales = new DatosGenerales
+                {
+                    Id = 10,
+                    Evento = "Falla en línea de transmisión",
+                    Fecha = DateTime.Parse("2024-10-31T18:13:57.837"),
+                    Hora = TimeSpan.Parse("08:30:00"),
+                    Subestacion = "Subestación Norte",
+                    LT = "LT-456",
+                    Equipo = "Equipo A"
+                },
+                Teleproteccion = new Teleproteccion
+                {
+                    Id = 10,
+                    TX_TEL = "TX-100",
+                    RX_TEL = "RX-100",
+                    TiempoMPLS = "200 ms"
+                },
+                DistanciaDeFalla = new DistanciaDeFalla
+                {
+                    Id = 10,
+                    DistanciaKM = "15 km",
+                    DistanciaPorcentaje = "75%",
+                    DistanciaReportada = "Distancia Reportada - 14 km",
+                    DistanciaDobleTemporal = "Distancia doble temporal - 10 km",
+                    Error = "0.5%",
+                    Error_Doble = "1%"
+                },
+                TiemposDeDisparo = new TiemposDeDisparo
+                {
+                    Id = 10,
+                    R = "30 ms",
+                    S = "40 ms",
+                    T = "50 ms",
+                    Reserva = "10 ms"
+                },
+                CorrientesDeFalla = new CorrientesDeFalla
+                {
+                    Id = 10,
+                    RealIR = "500 A",
+                    RealIS = "600 A",
+                    RealIT = "700 A",
+                    AcumuladaR = "1500 A",
+                    AcumuladaS = "1600 A",
+                    AcumuladaT = "1700 A"
+                },
+                Estado = 1
+            };
+
+            //Controlamos el retorno de los metodos privados que invoca VerificarInformesCompletosAsociados()
+            //en GestionarReporteConInformesService
+            _mockReporteDA.Setup(da => da.ObtenerIdsInformesDeReporte(It.IsAny<int>()))
+                          .ReturnsAsync(idsInformesAsociados);
+            
+            _mockInformeDA.Setup(da => da.ObtenerInformePorId(It.Is<int>(id => id == informe1Id)))
+                          .ReturnsAsync(informe1Completo);
+            _mockInformeDA.Setup(da => da.ObtenerInformePorId(It.Is<int>(id => id == informe2Id)))
+                          .ReturnsAsync(informe2Completo);
+
+            var resultado = await _gestionarReporteConInformesService.VerificarInformesCompletosAsociados(informe1Id);
+
+            Assert.IsTrue(resultado, "Se esperaba que todos los informes estuvieran completos con todos los datos instanciados y válidos.");
+        }
+
+
+        [Test]
+        public async Task ActualizarReporteValido_InformesConDatosCompletos_UnInformeCoNulos()
+        {
+            //Datos que usaran los metodos DA dentro de GestionarReporteConIformesService
+            int informe1Id = 10;
+            int informe2Id = 11;
+            var idsInformesAsociados = new List<int> { informe1Id, informe2Id };
+
+
+            //Informes
+            var informe1Completo = new Informe
+            {
+                Id = 10,
+                Tipo = 2,
+                SubestacionId = 1,
+                LineaTransmisionId = 1,
+                DatosDeLinea = new DatosDeLinea
+                {
+                    Id = 10,
+                    OT = null,
+                    Aviso = "Aviso-001",
+                    SAP = "SAP-56789",
+                    Distancia = "20 km",
+                    Funcion = "Función de protección",
+                    Zona = "Zona Norte"
+                },
+                DatosGenerales = new DatosGenerales
+                {
+                    Id = 10,
+                    Evento = "Falla en línea de transmisión",
+                    Fecha = DateTime.Parse("2024-10-31T18:13:57.837"),
+                    Hora = TimeSpan.Parse("08:30:00"),
+                    Subestacion = "Subestación Norte",
+                    LT = "LT-456",
+                    Equipo = "Equipo A"
+                },
+                Teleproteccion = new Teleproteccion
+                {
+                    Id = 10,
+                    TX_TEL = "TX-100",
+                    RX_TEL = "RX-100",
+                    TiempoMPLS = "200 ms"
+                },
+                DistanciaDeFalla = new DistanciaDeFalla
+                {
+                    Id = 10,
+                    DistanciaKM = "15 km",
+                    DistanciaPorcentaje = "75%",
+                    DistanciaReportada = "Distancia Reportada - 14 km",
+                    DistanciaDobleTemporal = "Distancia doble temporal - 10 km",
+                    Error = "0.5%",
+                    Error_Doble = "1%"
+                },
+                TiemposDeDisparo = new TiemposDeDisparo
+                {
+                    Id = 10,
+                    R = "30 ms",
+                    S = "40 ms",
+                    T = "50 ms",
+                    Reserva = "10 ms"
+                },
+                CorrientesDeFalla = new CorrientesDeFalla
+                {
+                    Id = 10,
+                    RealIR = "500 A",
+                    RealIS = "600 A",
+                    RealIT = "700 A",
+                    AcumuladaR = "1500 A",
+                    AcumuladaS = "1600 A",
+                    AcumuladaT = "1700 A"
+                },
+                Estado = 1
+            };
+
+            //Informes
+            var informe2Completo = new Informe
+            {
+                Id = 10,
+                Tipo = 2,
+                SubestacionId = 1,
+                LineaTransmisionId = 1,
+                DatosDeLinea = new DatosDeLinea
+                {
+                    Id = 10,
+                    OT = "OT-12345",
+                    Aviso = "Aviso-001",
+                    SAP = "SAP-56789",
+                    Distancia = "20 km",
+                    Funcion = "Función de protección",
+                    Zona = "Zona Norte"
+                },
+                DatosGenerales = new DatosGenerales
+                {
+                    Id = 10,
+                    Evento = "Falla en línea de transmisión",
+                    Fecha = DateTime.Parse("2024-10-31T18:13:57.837"),
+                    Hora = TimeSpan.Parse("08:30:00"),
+                    Subestacion = "Subestación Norte",
+                    LT = "LT-456",
+                    Equipo = "Equipo A"
+                },
+                Teleproteccion = new Teleproteccion
+                {
+                    Id = 10,
+                    TX_TEL = "TX-100",
+                    RX_TEL = "RX-100",
+                    TiempoMPLS = "200 ms"
+                },
+                DistanciaDeFalla = new DistanciaDeFalla
+                {
+                    Id = 10,
+                    DistanciaKM = "15 km",
+                    DistanciaPorcentaje = "75%",
+                    DistanciaReportada = "Distancia Reportada - 14 km",
+                    DistanciaDobleTemporal = "Distancia doble temporal - 10 km",
+                    Error = "0.5%",
+                    Error_Doble = "1%"
+                },
+                TiemposDeDisparo = new TiemposDeDisparo
+                {
+                    Id = 10,
+                    R = "30 ms",
+                    S = "40 ms",
+                    T = "50 ms",
+                    Reserva = "10 ms"
+                },
+                CorrientesDeFalla = new CorrientesDeFalla
+                {
+                    Id = 10,
+                    RealIR = "500 A",
+                    RealIS = "600 A",
+                    RealIT = "700 A",
+                    AcumuladaR = "1500 A",
+                    AcumuladaS = "1600 A",
+                    AcumuladaT = "1700 A"
+                },
+                Estado = 1
+            };
+
+            //Controlamos el retorno de los metodos privados que invoca VerificarInformesCompletosAsociados()
+            //en GestionarReporteConInformesService
+            _mockReporteDA.Setup(da => da.ObtenerIdsInformesDeReporte(It.IsAny<int>()))
+                          .ReturnsAsync(idsInformesAsociados);
+
+            _mockInformeDA.Setup(da => da.ObtenerInformePorId(It.Is<int>(id => id == informe1Id)))
+                          .ReturnsAsync(informe1Completo);
+            _mockInformeDA.Setup(da => da.ObtenerInformePorId(It.Is<int>(id => id == informe2Id)))
+                          .ReturnsAsync(informe2Completo);
+
+            var resultado = await _gestionarReporteConInformesService.VerificarInformesCompletosAsociados(informe1Id);
+
+            Assert.IsTrue(resultado, "Se esperaba que todos los informes estuvieran completos con todos los datos instanciados y válidos.");
+        }
+
+
+        [Test]
+        public async Task ActualizarReporteInvalido_InformesConDatosCompletos_InformesCoNulos()
+        {
+            //Datos que usaran los metodos DA dentro de GestionarReporteConIformesService
+            int informe1Id = 10;
+            int informe2Id = 11;
+            var idsInformesAsociados = new List<int> { informe1Id, informe2Id };
+
+
+            //Informes
+            var informe1Completo = new Informe
+            {
+                Id = 10,
+                Tipo = 2,
+                SubestacionId = 1,
+                LineaTransmisionId = 1,
+                DatosDeLinea = new DatosDeLinea
+                {
+                    Id = 10,
+                    OT = "OT-12345",
+                    Aviso = "Aviso-001",
+                    SAP = "SAP-56789",
+                    Distancia = "20 km",
+                    Funcion = "Función de protección",
+                    Zona = "Zona Norte"
+                },
+                DatosGenerales = new DatosGenerales
+                {
+                    Id = 10,
+                    Evento = "Falla en línea de transmisión",
+                    Fecha = DateTime.Parse("2024-10-31T18:13:57.837"),
+                    Hora = TimeSpan.Parse("08:30:00"),
+                    Subestacion = "Subestación Norte",
+                    LT = "LT-456",
+                    Equipo = "Equipo A"
+                },
+                Teleproteccion = new Teleproteccion
+                {
+                    Id = 10,
+                    TX_TEL = "TX-100",
+                    RX_TEL = "RX-100",
+                    TiempoMPLS = "200 ms"
+                },
+                DistanciaDeFalla = new DistanciaDeFalla
+                {
+                    Id = 10,
+                    DistanciaKM = "15 km",
+                    DistanciaPorcentaje = "75%",
+                    DistanciaReportada = "Distancia Reportada - 14 km",
+                    DistanciaDobleTemporal = "Distancia doble temporal - 10 km",
+                    Error = "0.5%",
+                    Error_Doble = "1%"
+                },
+                TiemposDeDisparo = new TiemposDeDisparo
+                {
+                    Id = 10,
+                    R = "30 ms",
+                    S = "40 ms",
+                    T = null,
+                    Reserva = "10 ms"
+                },
+                CorrientesDeFalla = new CorrientesDeFalla
+                {
+                    Id = 10,
+                    RealIR = "500 A",
+                    RealIS = "600 A",
+                    RealIT = "700 A",
+                    AcumuladaR = "1500 A",
+                    AcumuladaS = "1600 A",
+                    AcumuladaT = "1700 A"
+                },
+                Estado = 1
+            };
+
+            //Informes
+            var informe2Completo = new Informe
+            {
+                Id = 10,
+                Tipo = 2,
+                SubestacionId = 1,
+                LineaTransmisionId = 1,
+                DatosDeLinea = new DatosDeLinea
+                {
+                    Id = 10,
+                    OT = "OT-12345",
+                    Aviso = "Aviso-001",
+                    SAP = "SAP-56789",
+                    Distancia = "20 km",
+                    Funcion = "Función de protección",
+                    Zona = "Zona Norte"
+                },
+                DatosGenerales = new DatosGenerales
+                {
+                    Id = 10,
+                    Evento = "Falla en línea de transmisión",
+                    Fecha = DateTime.Parse("2024-10-31T18:13:57.837"),
+                    Hora = TimeSpan.Parse("08:30:00"),
+                    Subestacion = "Subestación Norte",
+                    LT = "LT-456",
+                    Equipo = "Equipo A"
+                },
+                Teleproteccion = new Teleproteccion
+                {
+                    Id = 10,
+                    TX_TEL = "TX-100",
+                    RX_TEL = "RX-100",
+                    TiempoMPLS = "200 ms"
+                },
+                DistanciaDeFalla = new DistanciaDeFalla
+                {
+                    Id = 10,
+                    DistanciaKM = "15 km",
+                    DistanciaPorcentaje = "75%",
+                    DistanciaReportada = "Distancia Reportada - 14 km",
+                    DistanciaDobleTemporal = "Distancia doble temporal - 10 km",
+                    Error = "0.5%",
+                    Error_Doble = null
+                },
+                TiemposDeDisparo = new TiemposDeDisparo
+                {
+                    Id = 10,
+                    R = "30 ms",
+                    S = "40 ms",
+                    T = "50 ms",
+                    Reserva = "10 ms"
+                },
+                CorrientesDeFalla = new CorrientesDeFalla
+                {
+                    Id = 10,
+                    RealIR = "500 A",
+                    RealIS = "600 A",
+                    RealIT = "700 A",
+                    AcumuladaR = "1500 A",
+                    AcumuladaS = "1600 A",
+                    AcumuladaT = "1700 A"
+                },
+                Estado = 1
+            };
+
+            //Controlamos el retorno de los metodos privados que invoca VerificarInformesCompletosAsociados()
+            //en GestionarReporteConInformesService
+            _mockReporteDA.Setup(da => da.ObtenerIdsInformesDeReporte(It.IsAny<int>()))
+                          .ReturnsAsync(idsInformesAsociados);
+
+            _mockInformeDA.Setup(da => da.ObtenerInformePorId(It.Is<int>(id => id == informe1Id)))
+                          .ReturnsAsync(informe1Completo);
+            _mockInformeDA.Setup(da => da.ObtenerInformePorId(It.Is<int>(id => id == informe2Id)))
+                          .ReturnsAsync(informe2Completo);
+
+            var resultado = await _gestionarReporteConInformesService.VerificarInformesCompletosAsociados(informe1Id);
+
+            Assert.IsFalse(resultado, "Se esperaba que todos los informes estuvieran completos con todos los datos instanciados y válidos.");
+        }
+
+        private Informe CrearInformePersonalizado(int id, string ot = "OT-12345", string aviso = "Aviso-001", bool incluirNulos = false)
+        {
+            return new Informe
+            {
+                Id = id,
+                Tipo = 2,
+                SubestacionId = 1,
+                LineaTransmisionId = 1,
+                DatosDeLinea = new DatosDeLinea
+                {
+                    Id = id,
+                    OT = incluirNulos ? null : ot,
+                    Aviso = aviso,
+                    SAP = "SAP-56789",
+                    Distancia = "20 km",
+                    Funcion = "Función de protección",
+                    Zona = "Zona Norte"
+                },
+                DatosGenerales = new DatosGenerales
+                {
+                    Id = id,
+                    Evento = "Falla en línea de transmisión",
+                    Fecha = DateTime.Parse("2024-10-31T18:13:57.837"),
+                    Hora = TimeSpan.Parse("08:30:00"),
+                    Subestacion = "Subestación Norte",
+                    LT = "LT-456",
+                    Equipo = "Equipo A"
+                },
+                Teleproteccion = new Teleproteccion
+                {
+                    Id = id,
+                    TX_TEL = "TX-100",
+                    RX_TEL = "RX-100",
+                    TiempoMPLS = "200 ms"
+                },
+                DistanciaDeFalla = new DistanciaDeFalla
+                {
+                    Id = id,
+                    DistanciaKM = "15 km",
+                    DistanciaPorcentaje = "75%",
+                    DistanciaReportada = "Distancia Reportada - 14 km",
+                    DistanciaDobleTemporal = "Distancia doble temporal - 10 km",
+                    Error = "0.5%",
+                    Error_Doble = "1%"
+                },
+                TiemposDeDisparo = new TiemposDeDisparo
+                {
+                    Id = id,
+                    R = "30 ms",
+                    S = "40 ms",
+                    T = "50 ms",
+                    Reserva = "10 ms"
+                },
+                CorrientesDeFalla = new CorrientesDeFalla
+                {
+                    Id = id,
+                    RealIR = "500 A",
+                    RealIS = "600 A",
+                    RealIT = "700 A",
+                    AcumuladaR = "1500 A",
+                    AcumuladaS = "1600 A",
+                    AcumuladaT = "1700 A"
+                },
+                Estado = 1
+            };
+        }
+
+    }
+}

--- a/Backend/ICE_Test/TestsUnitarios/GestionarReporteTest/ActualizarReporteTest.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarReporteTest/ActualizarReporteTest.cs
@@ -1,0 +1,166 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class ActualizarReporteTest
+    {
+        private Mock<IGestionarReporteDA> _mockReporteDA;
+        private Mock<IGestionarReporteConInformesService> _mockGestionarReporteConInformesService;
+        private GestionarReporteCN _gestionarReporteCN;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockReporteDA = new Mock<IGestionarReporteDA>();            
+            _mockGestionarReporteConInformesService = new Mock<IGestionarReporteConInformesService>();
+            _gestionarReporteCN = new GestionarReporteCN(_mockReporteDA.Object, _mockGestionarReporteConInformesService.Object);
+        }
+        
+        //Metodo que valida que las FK del reporte recibido para actualizar sean validas
+        [Test]
+        public async Task ActualizarReporteValido()
+        {
+            var reporte = new Reporte
+            {
+                Id = 1,
+                MapaDeDescargas = null,
+                Observaciones = null,
+                Evidencia = null,
+                ObservacionesTecnicoLinea = null,
+                Causas = null,
+                FechaHora = null,
+                InformeV1Id = 1,
+                InformeV2Id = 2,
+                InformeV3Id = 3,
+                InformeV4Id = 4,
+                UsuarioSupervisorId = 1,
+                TecnicoLineaId = 2,
+                Estado = 1
+            };
+
+            // Configurar el mock para simular la llamada exitosa
+
+                /////revisa Esto ChatGPT4.0 porfavor
+            _mockGestionarReporteConInformesService
+                .Setup(service => service.VerificarInformesCompletosAsociados(reporte.InformeV1Id))
+                .ReturnsAsync(true);
+
+            _mockGestionarReporteConInformesService
+                .Setup(service => service.ActualizarEstadoReporteSegunInformes(reporte))
+                .ReturnsAsync(true);
+
+
+            // Act
+            var resultado = await _gestionarReporteCN.ActualizarReporte(reporte.Id,reporte);
+
+            // Assert
+            Assert.IsTrue(resultado, "Se esperaba que el reporte fuera registrado con éxito con IDs válidos.");
+            _mockGestionarReporteConInformesService.Verify(service => service.ActualizarEstadoReporteSegunInformes(reporte), Times.Once);
+
+        }
+
+
+        [Test]
+        public async Task ActualizarReporteInvalido_EstadoInvalido()
+        {
+            var reporte = new Reporte
+            {
+                Estado = 0,
+                UsuarioSupervisorId = 1,
+                TecnicoLineaId = 1,
+                InformeV1Id = 1,
+                InformeV2Id = 2,
+                InformeV3Id = 3,
+                InformeV4Id = 4
+            };
+
+            // Act
+            var validacionReporte = await _gestionarReporteCN.ActualizarReporte(reporte.Id,reporte);
+
+            // Assert
+            Assert.IsFalse(validacionReporte, "El reporte debería ser inválido debido al estado fuera de rango.");
+            _mockGestionarReporteConInformesService.Verify(service => service.ActualizarEstadoReporteSegunInformes(It.IsAny<Reporte>()), Times.Never);
+
+        }
+
+        [Test]
+        public async Task ActualizarReporteInvalido_UsuarioSupervisorInvalido()
+        {
+            var reporte = new Reporte
+            {
+                Estado = 1,
+                UsuarioSupervisorId = -1,
+                TecnicoLineaId = 1,
+                InformeV1Id = 1,
+                InformeV2Id = 2,
+                InformeV3Id = 3,
+                InformeV4Id = 4
+            };
+
+            // Act
+            var validacionReporte = await _gestionarReporteCN.ActualizarReporte(reporte.Id, reporte);
+
+            // Assert
+            Assert.IsFalse(validacionReporte, "El reporte debería ser inválido debido al id del supervisor fuera de rango.");
+            _mockGestionarReporteConInformesService.Verify(service => service.ActualizarEstadoReporteSegunInformes(It.IsAny<Reporte>()), Times.Never);
+
+        }
+
+        [Test]
+        public async Task ActualizarReporteInvalido_UsuarioTecnicoInvalido()
+        {
+            var reporte = new Reporte
+            {
+                Estado = 1,
+                UsuarioSupervisorId = 1,
+                TecnicoLineaId = -1,
+                InformeV1Id = 1,
+                InformeV2Id = 2,
+                InformeV3Id = 3,
+                InformeV4Id = 4
+            };
+
+            // Act
+            var validacionReporte = await _gestionarReporteCN.ActualizarReporte(reporte.Id, reporte);
+
+            // Assert
+            Assert.IsFalse(validacionReporte, "El reporte debería ser inválido debido al id del técnico fuera de rango.");
+            _mockGestionarReporteConInformesService.Verify(service => service.ActualizarEstadoReporteSegunInformes(It.IsAny<Reporte>()), Times.Never);
+
+        }
+
+        [Test]
+        public async Task ActualizarReporteInvalido_InformesIdInvalidos()
+        {            
+            var idsInvalidos = new List<int> { -1, 0, -5, -3 };
+            foreach (var idInvalido in idsInvalidos)
+            {
+                var reporte = new Reporte
+                {
+                    Id = 1,
+                    Estado = 1,
+                    UsuarioSupervisorId = 1,
+                    TecnicoLineaId = 2,
+                    InformeV1Id = idInvalido,
+                    InformeV2Id = idInvalido,
+                    InformeV3Id = idInvalido,
+                    InformeV4Id = idInvalido
+                };
+                
+                var validacionReporte = await _gestionarReporteCN.ActualizarReporte(reporte.Id, reporte);
+                Assert.IsFalse(validacionReporte, $"El reporte debería ser inválido debido al ID inválido {idInvalido} en uno o más informes.");
+            }
+            _mockGestionarReporteConInformesService.Verify(service => service.ActualizarEstadoReporteSegunInformes(It.IsAny<Reporte>()), Times.Never);
+
+        }
+
+    }
+}

--- a/Backend/ICE_Test/TestsUnitarios/GestionarReporteTest/RegistrarReporteTest.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarReporteTest/RegistrarReporteTest.cs
@@ -1,0 +1,167 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class RegistrarReporteTest
+    {
+        private Mock<IGestionarReporteDA> _mockReporteDA;
+        private GestionarReporteConInformesService _gestionarReporteConInformesService;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockReporteDA = new Mock<IGestionarReporteDA>();
+
+            _gestionarReporteConInformesService = new GestionarReporteConInformesService(
+                new Mock<IGestionarInformeDA>().Object,
+                _mockReporteDA.Object,
+                new Mock<IGestionarTeleproteccionDA>().Object,
+                new Mock<IGestionarDistanciaDeFallaDA>().Object,
+                new Mock<IGestionarCorrientesDeFallaDA>().Object,
+                new Mock<IGestionarTiemposDeDisparoDA>().Object,
+                new Mock<IGestionarLineasTransmisionDA>().Object,
+                new Mock<IGestionarDatosDeLineaDA>().Object,
+                new Mock<IGestionarDatosGeneralesDA>().Object
+            );
+        }
+
+        [Test]
+        public async Task RegistrarReporteValido()
+        {            
+            var reporte = new Reporte
+            {
+                Id = 0,
+                MapaDeDescargas = null,
+                Observaciones = null,
+                Evidencia = null,
+                ObservacionesTecnicoLinea = null,
+                Causas = null,
+                FechaHora = null,
+                InformeV1Id = 0,
+                InformeV2Id = 0,
+                InformeV3Id = 0,
+                InformeV4Id = 0,
+                UsuarioSupervisorId = 1,
+                TecnicoLineaId = 2,
+                Estado = 0
+            };
+            var subestacionIds = new List<int> { 1, 2};
+            int lineaTransmisionId = 1;
+
+            // Configurar mock para simular la llamada exitosa
+            _mockReporteDA.Setup(da => da.RegistrarReporte(It.IsAny<Reporte>())).ReturnsAsync(true);
+
+            // Act
+            var resultado = await _gestionarReporteConInformesService.RegistrarReporteConInformes(reporte, subestacionIds, lineaTransmisionId);
+
+            // Assert
+            Assert.IsTrue(resultado, "Se esperaba que el reporte fuera registrado con éxito con IDs válidos.");
+            _mockReporteDA.Verify(da => da.RegistrarReporte(It.IsAny<Reporte>()), Times.Once);
+        }
+
+        [Test]
+        public async Task RegistrarReporteInvalido_SubestacionesIdInvalidas()
+        {
+            var reporte = new Reporte
+            {
+                Id = 0,
+                MapaDeDescargas = null,
+                Observaciones = null,
+                Evidencia = null,
+                ObservacionesTecnicoLinea = null,
+                Causas = null,
+                FechaHora = null,
+                InformeV1Id = 0,
+                InformeV2Id = 0,
+                InformeV3Id = 0,
+                InformeV4Id = 0,
+                UsuarioSupervisorId = 1,
+                TecnicoLineaId = 2,
+                Estado = 0
+            };
+            var subestacionIds = new List<int> { 1, -2};
+            int lineaTransmisionId = 1;
+
+            // Act
+            var resultado = await _gestionarReporteConInformesService.RegistrarReporteConInformes(reporte, subestacionIds, lineaTransmisionId);
+
+            // Assert
+            Assert.IsFalse(resultado, "Se esperaba que la validación fallara con un ID de subestación inválido.");
+            _mockReporteDA.Verify(da => da.RegistrarReporte(It.IsAny<Reporte>()), Times.Never);
+        }
+
+        [Test]
+        public async Task RegistrarReporteInvalido_LineaTransmisionIdInvalido()
+        {
+            var reporte = new Reporte
+            {
+                Id = 0,
+                MapaDeDescargas = null,
+                Observaciones = null,
+                Evidencia = null,
+                ObservacionesTecnicoLinea = null,
+                Causas = null,
+                FechaHora = null,
+                InformeV1Id = 0,
+                InformeV2Id = 0,
+                InformeV3Id = 0,
+                InformeV4Id = 0,
+                UsuarioSupervisorId = 1,
+                TecnicoLineaId = 2,
+                Estado = 0
+            };
+            var subestacionIds = new List<int> { 1, 2};
+            int lineaTransmisionId = -1;
+
+            // Act
+            var resultado = await _gestionarReporteConInformesService.RegistrarReporteConInformes(reporte, subestacionIds, lineaTransmisionId);
+
+            // Assert
+            Assert.IsFalse(resultado, "Se esperaba que la validación fallara con un ID de línea de transmisión inválido.");
+            _mockReporteDA.Verify(da => da.RegistrarReporte(It.IsAny<Reporte>()), Times.Never);
+        }
+
+        [Test]
+        public async Task RegistrarReporteInvalido_UsuarioSupervisorIdInvalido()
+        {            
+            var reporte = new Reporte
+            {
+                UsuarioSupervisorId = 0,
+                TecnicoLineaId = 2
+            };
+            var subestacionIds = new List<int> { 1, 2};
+            int lineaTransmisionId = 1;
+
+            // Act
+            var resultado = await _gestionarReporteConInformesService.RegistrarReporteConInformes(reporte, subestacionIds, lineaTransmisionId);
+
+            // Assert
+            Assert.IsFalse(resultado, "Se esperaba que la validación fallara con un ID de supervisor inválido.");
+            _mockReporteDA.Verify(da => da.RegistrarReporte(It.IsAny<Reporte>()), Times.Never);
+        }
+
+        [Test]
+        public async Task RegistrarReporteInvalido_TecnicoLineaIdInvalido()
+        {            
+            var reporte = new Reporte
+            {
+                UsuarioSupervisorId = 1,
+                TecnicoLineaId = 0
+            };
+            var subestacionIds = new List<int> { 1, 2};
+            int lineaTransmisionId = 1;
+         
+            var resultado = await _gestionarReporteConInformesService.RegistrarReporteConInformes(reporte, subestacionIds, lineaTransmisionId);
+
+            Assert.IsFalse(resultado, "Se esperaba que la validación fallara con un ID de técnico de línea inválido.");
+            _mockReporteDA.Verify(da => da.RegistrarReporte(It.IsAny<Reporte>()), Times.Never);
+        }
+    }
+}

--- a/Backend/ICE_Test/TestsUnitarios/GestionarSubestacionTest/ActualizarSubestacionTest.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarSubestacionTest/ActualizarSubestacionTest.cs
@@ -1,0 +1,102 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class ActualizarSubestacionTest
+    {
+        private Mock<IGestionarSubestacionDA> _mockSubestacionDA;
+        private GestionarSubestacionCN _gestionarSubestacionCN;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Se instancia la clase de bd asociada para manipular sus resultados
+            _mockSubestacionDA = new Mock<IGestionarSubestacionDA>();
+            // Clase de la cual se probarán los métodos
+            _gestionarSubestacionCN = new GestionarSubestacionCN(_mockSubestacionDA.Object);
+        }
+
+        [Test]
+        public async Task ActualizarSubestacionValida()
+        {
+            // Arrange
+            var subestacion = new Subestacion
+            {
+                NombreUbicacion = "Ubicacion 1",
+                Identificador = "ID-001",
+                UnidadRegionalId = 1
+            };
+            _mockSubestacionDA.Setup(da => da.ActualizarSubestacion(1, subestacion)).ReturnsAsync(true);
+
+            // Act
+            var resultado = await _gestionarSubestacionCN.ActualizarSubestacion(1, subestacion);
+
+            // Assert
+            Assert.IsTrue(resultado, "La actualización debería ser exitosa para una subestación válida.");
+            _mockSubestacionDA.Verify(da => da.ActualizarSubestacion(1, subestacion), Times.Once);
+        }
+
+        [Test]
+        public async Task ActualizarSubestacionInvalida_NombreUbicacionInvalido()
+        {
+            var subestacionesInvalidas = new List<Subestacion>
+            {
+                new Subestacion { NombreUbicacion = "", Identificador = "ID-001", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = "    ", Identificador = "ID-123", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = "   ", Identificador = "ID-001", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = new string('a', 101), Identificador = "ID-001", UnidadRegionalId = 1 }
+            };
+
+            foreach (var subestacion in subestacionesInvalidas)
+            {
+                var resultado = await _gestionarSubestacionCN.ActualizarSubestacion(1, subestacion);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {subestacion}");
+                _mockSubestacionDA.Verify(da => da.ActualizarSubestacion(It.IsAny<int>(), It.IsAny<Subestacion>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task ActualizarSubestacionInvalida_IdentificadorInvalido()
+        {
+            var subestacionesInvalidas = new List<Subestacion>
+            {
+                new Subestacion { NombreUbicacion = "Orosi", Identificador = "", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = "Tapanti", Identificador = " ", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = "Rio Macho", Identificador = "   ", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = "Rio Macho", Identificador = "Ca", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = "Quetzal", Identificador = new string('a', 21), UnidadRegionalId = 1 }
+            };
+
+            foreach (var subestacion in subestacionesInvalidas)
+            {
+                var resultado = await _gestionarSubestacionCN.ActualizarSubestacion(1, subestacion);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {subestacion}");
+                _mockSubestacionDA.Verify(da => da.ActualizarSubestacion(It.IsAny<int>(), It.IsAny<Subestacion>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task ActualizarSubestacionInvalida_UnidadRegionalInvalida()
+        {
+            var subestacionesInvalidas = new List<Subestacion>
+            {
+                new Subestacion { NombreUbicacion = "Rio Macho", Identificador = "Sub_111", UnidadRegionalId = -12 },
+                new Subestacion { NombreUbicacion = "Quetzal", Identificador = "Subestacion_RioMachoOrosi", UnidadRegionalId = 0 }
+            };
+
+            foreach (var subestacion in subestacionesInvalidas)
+            {
+                var resultado = await _gestionarSubestacionCN.ActualizarSubestacion(1, subestacion);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {subestacion}");
+                _mockSubestacionDA.Verify(da => da.ActualizarSubestacion(It.IsAny<int>(), It.IsAny<Subestacion>()), Times.Never);
+            }
+        }
+    }
+}

--- a/Backend/ICE_Test/TestsUnitarios/GestionarSubestacionTest/RegistrarSubestacionTest.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarSubestacionTest/RegistrarSubestacionTest.cs
@@ -1,0 +1,107 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using ICE.Capa_Dominio.ReglasDeNegocio;
+using Moq;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class RegistrarSubestacionTest
+    {
+        private Mock<IGestionarSubestacionDA> _mockSubestacionDA;
+        private GestionarSubestacionCN _gestionarSubestacionCN;
+
+        [SetUp]
+        public void Setup()
+        {
+            //Se instancia la clase de bd asociada para manipular sus resultados
+            _mockSubestacionDA = new Mock<IGestionarSubestacionDA>();
+            //Clase de la cual se probaran los metodos
+            _gestionarSubestacionCN = new GestionarSubestacionCN(_mockSubestacionDA.Object);
+        }
+
+        [Test]
+        public async Task RegistrarSubestacionValida()
+        {
+            // Arrange
+            var subestacion = new Subestacion
+            {
+                NombreUbicacion = "Ubicacion 1",
+                Identificador = "ID-001",
+                UnidadRegionalId = 1
+            };
+            _mockSubestacionDA.Setup(da => da.RegistrarSubestacion(subestacion)).ReturnsAsync(true);
+
+            // Act
+            var resultado = await _gestionarSubestacionCN.RegistrarSubestacion(subestacion);
+
+            // Assert
+            Assert.IsTrue(resultado);
+            _mockSubestacionDA.Verify(da => da.RegistrarSubestacion(subestacion), Times.Once);
+        }
+
+        [Test]
+        public async Task RegistrarSubestacionInvalida_NombreUbicacionInvalido()
+        {            
+            var subestacionesInvalidas = new List<Subestacion>
+            {
+                new Subestacion { NombreUbicacion = "", Identificador = "ID-001", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = " ", Identificador = "ID-123", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = "   ", Identificador = "ID-001", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = new string('a', 101), Identificador = "ID-001", UnidadRegionalId = 1 }
+            };
+
+            foreach (var subestacion in subestacionesInvalidas)
+            {
+                var resultado = await _gestionarSubestacionCN.RegistrarSubestacion(subestacion);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {subestacion}");
+                _mockSubestacionDA.Verify(da => da.RegistrarSubestacion(It.IsAny<Subestacion>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task RegistrarSubestacionInvalida_IdentificadorInvalido()
+        {
+            var subestacionesInvalidas = new List<Subestacion>
+            {
+                new Subestacion { NombreUbicacion = "Orosi", Identificador = "", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = "Tapanti", Identificador = " ", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = "Rio Macho", Identificador = "   ", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = "Rio Macho", Identificador = "Ca", UnidadRegionalId = 1 },
+                new Subestacion { NombreUbicacion = "Quetzal", Identificador = new string('a', 21), UnidadRegionalId = 1 }
+            };
+
+            foreach (var subestacion in subestacionesInvalidas)
+            {
+                var resultado = await _gestionarSubestacionCN.RegistrarSubestacion(subestacion);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {subestacion}");
+                _mockSubestacionDA.Verify(da => da.RegistrarSubestacion(It.IsAny<Subestacion>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task RegistrarSubestacionInvalida_UnidadRegionalInvalida()
+        {
+            var subestacionesInvalidas = new List<Subestacion>
+            {                
+                new Subestacion { NombreUbicacion = "Rio Macho", Identificador = "Sub_111", UnidadRegionalId = -12 },
+                new Subestacion { NombreUbicacion = "Quetzal", Identificador = "Subestacion_RioMachoOrosi", UnidadRegionalId = 0 }
+            };
+
+            foreach (var subestacion in subestacionesInvalidas)
+            {
+                var resultado = await _gestionarSubestacionCN.RegistrarSubestacion(subestacion);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {subestacion}");
+                _mockSubestacionDA.Verify(da => da.RegistrarSubestacion(It.IsAny<Subestacion>()), Times.Never);
+            }
+        }
+
+
+        //Falta Agregar el Metodo sobre Identificador que coincide con uno de la BD
+    }
+}

--- a/Backend/ICE_Test/TestsUnitarios/GestionarUnidadRegionalTest/ActualizarUnidadRegionalTest.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarUnidadRegionalTest/ActualizarUnidadRegionalTest.cs
@@ -1,0 +1,84 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class ActualizarUnidadRegionalTest
+    {
+        private Mock<IGestionarUnidadRegionalDA> _mockUnidadRegionalDA;
+        private GestionarUnidadRegionalCN _gestionarUnidadRegionalCN;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Se instancia la clase de base de datos asociada para manipular sus resultados
+            _mockUnidadRegionalDA = new Mock<IGestionarUnidadRegionalDA>();
+            // Clase de la cual se probarán los métodos
+            _gestionarUnidadRegionalCN = new GestionarUnidadRegionalCN(_mockUnidadRegionalDA.Object);
+        }
+
+        [Test]
+        public async Task ActualizarUnidadRegionalValida()
+        {
+            // Arrange
+            var unidadRegional = new UnidadRegional
+            {
+                NombreUbicacion = "Ubicacion Actualizada",
+                Identificador = "UR-001"
+            };
+            _mockUnidadRegionalDA.Setup(da => da.ActualizarUnidadRegional(1, unidadRegional)).ReturnsAsync(true);
+
+            // Act
+            var resultado = await _gestionarUnidadRegionalCN.ActualizarUnidadRegional(1, unidadRegional);
+
+            // Assert
+            Assert.IsTrue(resultado, "La actualización debería ser exitosa para una unidad regional válida.");
+            _mockUnidadRegionalDA.Verify(da => da.ActualizarUnidadRegional(1, unidadRegional), Times.Once);
+        }
+
+        [Test]
+        public async Task ActualizarUnidadRegionalInvalida_NombreUbicacionInvalido()
+        {
+            var unidadesInvalidas = new List<UnidadRegional>
+            {
+                new UnidadRegional { NombreUbicacion = "", Identificador = "UR-001" },
+                new UnidadRegional { NombreUbicacion = " ", Identificador = "UR-123" },
+                new UnidadRegional { NombreUbicacion = "   ", Identificador = "UR-001" },
+                new UnidadRegional { NombreUbicacion = new string('a', 101), Identificador = "UR-001" }
+            };
+
+            foreach (var unidad in unidadesInvalidas)
+            {
+                var resultado = await _gestionarUnidadRegionalCN.ActualizarUnidadRegional(1, unidad);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {unidad}");
+                _mockUnidadRegionalDA.Verify(da => da.ActualizarUnidadRegional(It.IsAny<int>(), It.IsAny<UnidadRegional>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task ActualizarUnidadRegionalInvalida_IdentificadorInvalido()
+        {
+            var unidadesInvalidas = new List<UnidadRegional>
+            {
+                new UnidadRegional { NombreUbicacion = "Orosi", Identificador = "" },
+                new UnidadRegional { NombreUbicacion = "Tapanti", Identificador = " " },
+                new UnidadRegional { NombreUbicacion = "Rio Macho", Identificador = "   " },
+                new UnidadRegional { NombreUbicacion = "Rio Macho", Identificador = "Ca" },
+                new UnidadRegional { NombreUbicacion = "Quetzal", Identificador = new string('a', 21) }
+            };
+
+            foreach (var unidad in unidadesInvalidas)
+            {
+                var resultado = await _gestionarUnidadRegionalCN.ActualizarUnidadRegional(1, unidad);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {unidad}");
+                _mockUnidadRegionalDA.Verify(da => da.ActualizarUnidadRegional(It.IsAny<int>(), It.IsAny<UnidadRegional>()), Times.Never);
+            }
+        }
+    }
+}

--- a/Backend/ICE_Test/TestsUnitarios/GestionarUnidadRegionalTest/GestionarUnidadRegionalTest.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarUnidadRegionalTest/GestionarUnidadRegionalTest.cs
@@ -1,0 +1,88 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using ICE.Capa_Dominio.ReglasDeNegocio;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class RegistrarUnidadRegionalTest
+    {
+        private Mock<IGestionarUnidadRegionalDA> _mockUnidadRegionalDA;
+        private GestionarUnidadRegionalCN _gestionarUnidadRegionalCN;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Se instancia la clase de base de datos asociada para manipular sus resultados
+            _mockUnidadRegionalDA = new Mock<IGestionarUnidadRegionalDA>();
+            // Clase de la cual se probarán los métodos
+            _gestionarUnidadRegionalCN = new GestionarUnidadRegionalCN(_mockUnidadRegionalDA.Object);
+        }
+
+        [Test]
+        public async Task RegistrarUnidadRegionalValida()
+        {
+            // Arrange
+            var unidadRegional = new UnidadRegional
+            {
+                NombreUbicacion = "Ubicacion Principal",
+                Identificador = "UR-001"
+            };
+            _mockUnidadRegionalDA.Setup(da => da.RegistrarUnidadRegional(unidadRegional)).ReturnsAsync(true);
+
+            // Act
+            var resultado = await _gestionarUnidadRegionalCN.RegistrarUnidadRegional(unidadRegional);
+
+            // Assert
+            Assert.IsTrue(resultado);
+            _mockUnidadRegionalDA.Verify(da => da.RegistrarUnidadRegional(unidadRegional), Times.Once);
+        }
+
+        [Test]
+        public async Task RegistrarUnidadRegionalInvalida_NombreUbicacionInvalido()
+        {
+            var unidadesInvalidas = new List<UnidadRegional>
+            {
+                new UnidadRegional { NombreUbicacion = "", Identificador = "UR-001" },
+                new UnidadRegional { NombreUbicacion = " ", Identificador = "UR-123" },
+                new UnidadRegional { NombreUbicacion = "   ", Identificador = "UR-001" },
+                new UnidadRegional { NombreUbicacion = new string('a', 101), Identificador = "UR-001" }
+            };
+
+            foreach (var unidad in unidadesInvalidas)
+            {
+                var resultado = await _gestionarUnidadRegionalCN.RegistrarUnidadRegional(unidad);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {unidad}");
+                _mockUnidadRegionalDA.Verify(da => da.RegistrarUnidadRegional(It.IsAny<UnidadRegional>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task RegistrarUnidadRegionalInvalida_IdentificadorInvalido()
+        {
+            var unidadesInvalidas = new List<UnidadRegional>
+            {
+                new UnidadRegional { NombreUbicacion = "Orosi", Identificador = "" },
+                new UnidadRegional { NombreUbicacion = "Tapanti", Identificador = " " },
+                new UnidadRegional { NombreUbicacion = "Rio Macho", Identificador = "   " },
+                new UnidadRegional { NombreUbicacion = "Rio Macho", Identificador = "Ca" },
+                new UnidadRegional { NombreUbicacion = "Quetzal", Identificador = new string('a', 21) }
+            };
+
+            foreach (var unidad in unidadesInvalidas)
+            {
+                var resultado = await _gestionarUnidadRegionalCN.RegistrarUnidadRegional(unidad);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {unidad}");
+                _mockUnidadRegionalDA.Verify(da => da.RegistrarUnidadRegional(It.IsAny<UnidadRegional>()), Times.Never);
+            }
+        }
+
+        //Falta Agregar el Metodo sobre Identificador que coincide con uno de la BD
+    }
+}

--- a/Backend/ICE_Test/TestsUnitarios/GestionarUsuario/ActualizarUsuarioTest.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarUsuario/ActualizarUsuarioTest.cs
@@ -1,0 +1,120 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class ActualizarUsuarioTest
+    {
+        private Mock<IGestionarUsuarioDA> _mockUsuarioDA;
+        private GestionarUsuarioCN _gestionarUsuarioCN;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Instancia la clase de base de datos para manipular sus resultados
+            _mockUsuarioDA = new Mock<IGestionarUsuarioDA>();
+            // Clase de la cual se probarán los métodos
+            _gestionarUsuarioCN = new GestionarUsuarioCN(_mockUsuarioDA.Object);
+        }
+
+        [Test]
+        public async Task ActualizarUsuarioValido()
+        {
+            // Arrange
+            var usuario = new Usuario
+            {
+                NombreUsuario = "usuario_valido",
+                Contrasenia = "Contrasenia123",
+                Identificador = "ID-001",
+                Rol = "Admin",
+                SubestacionId = 1,
+                UnidadRegionalId = 1,
+                Nombre = "Nombre",
+                Apellido = "Apellido",
+                Correo = "correo@ejemplo.com"
+            };
+            _mockUsuarioDA.Setup(da => da.ActualizarUsuario(1, usuario)).ReturnsAsync(true);
+
+            // Act
+            var resultado = await _gestionarUsuarioCN.ActualizarUsuario(1, usuario);
+
+            // Assert
+            Assert.IsTrue(resultado, "La actualización debería ser exitosa para un usuario válido.");
+            _mockUsuarioDA.Verify(da => da.ActualizarUsuario(1, usuario), Times.Once);
+        }
+
+        [Test]
+        public async Task ActualizarUsuarioInvalido_NombreUsuarioInvalido()
+        {
+            var usuariosInvalidos = new List<Usuario>
+            {
+                new Usuario { NombreUsuario = "", Contrasenia = "Contrasenia123", Identificador = "ID-001", Rol = "Admin", SubestacionId = 1 },
+                new Usuario { NombreUsuario = new string('a', 101), Contrasenia = "Contrasenia123", Identificador = "ID-002", Rol = "User", SubestacionId = 2 }
+            };
+
+            foreach (var usuario in usuariosInvalidos)
+            {
+                var resultado = await _gestionarUsuarioCN.ActualizarUsuario(1, usuario);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {usuario}");
+                _mockUsuarioDA.Verify(da => da.ActualizarUsuario(It.IsAny<int>(), It.IsAny<Usuario>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task ActualizarUsuarioInvalido_ContraseniaInvalida()
+        {
+            var usuariosInvalidos = new List<Usuario>
+            {
+                new Usuario { NombreUsuario = "usuario1", Contrasenia = "", Identificador = "ID-001", Rol = "Admin", SubestacionId = 1 },
+                new Usuario { NombreUsuario = "usuario2", Contrasenia = "12345", Identificador = "ID-002", Rol = "User", SubestacionId = 2 }
+            };
+
+            foreach (var usuario in usuariosInvalidos)
+            {
+                var resultado = await _gestionarUsuarioCN.ActualizarUsuario(1, usuario);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {usuario}");
+                _mockUsuarioDA.Verify(da => da.ActualizarUsuario(It.IsAny<int>(), It.IsAny<Usuario>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task ActualizarUsuarioInvalido_IdentificadorInvalido()
+        {
+            var usuariosInvalidos = new List<Usuario>
+            {
+                new Usuario { NombreUsuario = "usuario1", Contrasenia = "Contrasenia123", Identificador = "", Rol = "Admin", SubestacionId = 1 },
+                new Usuario { NombreUsuario = "usuario2", Contrasenia = "Contrasenia456", Identificador = "   ", Rol = "User", SubestacionId = 2 }
+            };
+
+            foreach (var usuario in usuariosInvalidos)
+            {
+                var resultado = await _gestionarUsuarioCN.ActualizarUsuario(1, usuario);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {usuario}");
+                _mockUsuarioDA.Verify(da => da.ActualizarUsuario(It.IsAny<int>(), It.IsAny<Usuario>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task ActualizarUsuarioInvalido_CorreoInvalido()
+        {
+            var usuariosInvalidos = new List<Usuario>
+            {
+                new Usuario { NombreUsuario = "usuario1", Contrasenia = "Contrasenia123", Identificador = "ID-001", Rol = "Admin", SubestacionId = 1, Correo = "correosinarroba.com" },
+                new Usuario { NombreUsuario = "usuario2", Contrasenia = "Contrasenia456", Identificador = "ID-002", Rol = "User", SubestacionId = 2, Correo = "correo@sinpunto" }
+            };
+
+            foreach (var usuario in usuariosInvalidos)
+            {
+                var resultado = await _gestionarUsuarioCN.ActualizarUsuario(1, usuario);
+                Assert.IsFalse(resultado, $"La validación falló para el caso: {usuario}");
+                _mockUsuarioDA.Verify(da => da.ActualizarUsuario(It.IsAny<int>(), It.IsAny<Usuario>()), Times.Never);
+            }
+        }
+    }
+}

--- a/Backend/ICE_Test/TestsUnitarios/GestionarUsuario/RegistrarUsuarioTest.cs
+++ b/Backend/ICE_Test/TestsUnitarios/GestionarUsuario/RegistrarUsuarioTest.cs
@@ -1,0 +1,124 @@
+using ICE.Capa_Dominio.Modelos;
+using ICE.Capa_Negocios.CU;
+using ICE.Capa_Negocios.Interfaces.Capa_Negocios;
+using ICE.Capa_Negocios.Interfaces.Capa_Datos;
+using ICE.Capa_Dominio.ReglasDeNegocio;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ICE_Test.TestsUnitarios
+{
+    [TestFixture]
+    public class RegistrarUsuarioTest
+    {
+        private Mock<IGestionarUsuarioDA> _mockUsuarioDA;
+        private GestionarUsuarioCN _gestionarUsuarioCN;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Instancia la clase de base de datos para manipular sus resultados
+            _mockUsuarioDA = new Mock<IGestionarUsuarioDA>();
+            // Clase de la cual se probarán los métodos
+            _gestionarUsuarioCN = new GestionarUsuarioCN(_mockUsuarioDA.Object);
+        }
+
+        [Test]
+        public async Task RegistrarUsuarioValido()
+        {
+            // Arrange
+            var usuario = new Usuario
+            {
+                NombreUsuario = "usuario_valido",
+                Contrasenia = "Contrasenia123",
+                Identificador = "ID-001",
+                Rol = "Admin",
+                SubestacionId = 1,
+                UnidadRegionalId = 1,
+                Nombre = "Nombre",
+                Apellido = "Apellido",
+                Correo = "correo@ejemplo.com"
+            };
+            _mockUsuarioDA.Setup(da => da.RegistrarUsuario(usuario)).ReturnsAsync(1);
+
+            // Act
+            var resultado = await _gestionarUsuarioCN.RegistrarUsuario(usuario);
+
+            // Assert
+            Assert.Greater(resultado, 0, "El ID del usuario debería ser mayor que 0 para indicar éxito.");
+            _mockUsuarioDA.Verify(da => da.RegistrarUsuario(usuario), Times.Once);
+        }
+
+        [Test]
+        public async Task RegistrarUsuarioInvalido_NombreUsuarioInvalido()
+        {
+            var usuariosInvalidos = new List<Usuario>
+            {
+                new Usuario { NombreUsuario = "", Contrasenia = "Contrasenia123", Identificador = "ID-001", Rol = "Admin", SubestacionId = 1 },
+                new Usuario { NombreUsuario = new string('a', 101), Contrasenia = "Contrasenia123", Identificador = "ID-002", Rol = "User", SubestacionId = 2 }
+            };
+
+            foreach (var usuario in usuariosInvalidos)
+            {
+                var resultado = await _gestionarUsuarioCN.RegistrarUsuario(usuario);
+                Assert.AreEqual(0, resultado, $"La validación falló para el caso: {usuario}");
+                _mockUsuarioDA.Verify(da => da.RegistrarUsuario(It.IsAny<Usuario>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task RegistrarUsuarioInvalido_ContraseniaInvalida()
+        {
+            var usuariosInvalidos = new List<Usuario>
+            {
+                new Usuario { NombreUsuario = "usuario1", Contrasenia = "", Identificador = "ID-001", Rol = "Admin", SubestacionId = 1 },
+                new Usuario { NombreUsuario = "usuario2", Contrasenia = "12345", Identificador = "ID-002", Rol = "User", SubestacionId = 2 }
+            };
+
+            foreach (var usuario in usuariosInvalidos)
+            {             
+                var resultado = await _gestionarUsuarioCN.RegistrarUsuario(usuario);
+                Assert.AreEqual(0, resultado, $"La validación falló para el caso: {usuario}");
+                _mockUsuarioDA.Verify(da => da.RegistrarUsuario(It.IsAny<Usuario>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task RegistrarUsuarioInvalido_IdentificadorInvalido()
+        {
+            var usuariosInvalidos = new List<Usuario>
+            {
+                new Usuario { NombreUsuario = "usuario1", Contrasenia = "Contrasenia123", Identificador = "", Rol = "Admin", SubestacionId = 1 },
+                new Usuario { NombreUsuario = "usuario2", Contrasenia = "Contrasenia456", Identificador = "   ", Rol = "User", SubestacionId = 2 }
+            };
+
+            foreach (var usuario in usuariosInvalidos)
+            {                
+                var resultado = await _gestionarUsuarioCN.RegistrarUsuario(usuario);
+                Assert.AreEqual(0, resultado, $"La validación falló para el caso: {usuario}");
+                _mockUsuarioDA.Verify(da => da.RegistrarUsuario(It.IsAny<Usuario>()), Times.Never);
+            }
+        }
+
+        [Test]
+        public async Task RegistrarUsuarioInvalido_CorreoInvalido()
+        {
+            var usuariosInvalidos = new List<Usuario>
+            {
+                new Usuario { NombreUsuario = "usuario1", Contrasenia = "Contrasenia123", Identificador = "ID-001", Rol = "Admin", SubestacionId = 1, Correo = "correosinarroba.com" },
+                new Usuario { NombreUsuario = "usuario2", Contrasenia = "Contrasenia456", Identificador = "ID-002", Rol = "User", SubestacionId = 2, Correo = "correo@sinpunto" }
+            };
+
+            foreach (var usuario in usuariosInvalidos)
+            {                
+                var resultado = await _gestionarUsuarioCN.RegistrarUsuario(usuario);
+                Assert.AreEqual(0, resultado, $"La validación falló para el caso: {usuario}");
+                _mockUsuarioDA.Verify(da => da.RegistrarUsuario(It.IsAny<Usuario>()), Times.Never);
+            }
+        }
+
+        //Falta Agregar el Metodo sobre Identificador que coincide con uno de la BD
+    }
+}


### PR DESCRIPTION
Se crean las pruebas unitarias para los Casos de Uso Actualizar (Editar):
ActualizarSubestación
ActualizarUnidadRegional
ActualizarLíneaTransmisión
ActualizarUsuario
ActualizarReporte

Se agregan nuevas validaciones en reglas de negocio para evitar que los datos puedan venir en blacno, para delimitar los identificadores a solo 3 o 20 caracteres. Las reglas fueron:
ReglasLineaTransmisino
ReglasReporte
ReglasUnidadRegional
ReglasUsuario


Se crean las pruebas unitarias de los Casos de Uso de Registrar (Agregar) :
Subestación
Registrar Unidad Regional.
Registrar Línea Transmisión
RegistrarUsuario
RegistrarReporte
